### PR TITLE
Add new rest trigger for new engine

### DIFF
--- a/trigger/rest_incubator/README.md
+++ b/trigger/rest_incubator/README.md
@@ -1,0 +1,117 @@
+# tibco-rest
+This trigger provides your flogo application the ability to start a flow via REST over HTTP
+
+## Installation
+
+```bash
+flogo add trigger github.com/TIBCOSoftware/flogo-contrib/trigger/rest
+```
+
+## Schema
+Settings, Outputs and Endpoint:
+
+```json
+{
+  "settings": [
+    {
+      "name": "port",
+      "type": "integer"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "pathParams",
+      "type": "params"
+    },
+    {
+      "name": "queryParams",
+      "type": "params"
+    },
+    {
+      "name": "content",
+      "type": "object"
+    }
+  ],
+  "endpoint": {
+    "settings": [
+      {
+        "name": "method",
+        "type": "string",
+        "required" : true
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "required" : true
+      }
+    ]
+  }
+}
+```
+## Settings
+### Trigger:
+| Setting     | Description    |
+|:------------|:---------------|
+| port | The port to listen on |         
+### Endpoint:
+| Setting     | Description    |
+|:------------|:---------------|
+| method      | The HTTP method |         
+| path        | The resource path  |
+
+
+## Example Configurations
+
+Triggers are configured via the triggers.json of your application. The following are some example configuration of the REST Trigger.
+
+### POST
+Configure the Trigger to handle a POST on /device
+
+```json
+{
+  "triggers": [
+    {
+      "name": "tibco-rest",
+      "settings": {
+        "port": "8080"
+      },
+      "endpoints": [
+        {
+          "actionType": "flow",
+          "actionURI": "embedded://new_device_flow",
+          "settings": {
+            "method": "POST",
+            "path": "/device"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### GET
+Configure the Trigger to handle a GET on /device/:id
+
+```json
+{
+  "triggers": [
+    {
+      "name": "tibco-rest",
+      "settings": {
+        "port": "8080"
+      },
+      "endpoints": [
+        {
+          "actionType": "flow",
+          "actionURI": "embedded://get_device_flow",
+          "settings": {
+            "method": "GET",
+            "path": "/device/:id"
+          }
+        }
+      ]
+    }
+  ]
+}
+```

--- a/trigger/rest_incubator/runtime/cors/cors.go
+++ b/trigger/rest_incubator/runtime/cors/cors.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2015 TIBCO Software Inc.
+// All Rights Reserved.
+
+//Cors package to validate CORS requests and provide the correct headers in the response
+package cors
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/op/go-logging"
+)
+
+const (
+	ORIGIN_HEADER                           string = "Origin"
+	ACCESS_CONTROL_REQUEST_METHOD_HEADER    string = "Access-Control-Request-Method"
+	ACCESS_CONTROL_REQUEST_HEADER_HEADER    string = "Access-Control-Request-Headers"
+	ACCESS_CONTROL_ALLOW_ORIGIN_HEADER      string = "Access-Control-Allow-Origin"
+	ACCESS_CONTROL_ALLOW_METHODS_HEADER     string = "Access-Control-Allow-Methods"
+	ACCESS_CONTROL_ALLOW_HEADERS_HEADER     string = "Access-Control-Allow-Headers"
+	ACCESS_CONTROL_EXPOSE_HEADERS_HEADER    string = "Access-Control-Expose-Headers"
+	ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER string = "Access-Control-Allow-Credentials"
+	ACCESS_CONTROL_MAX_AGE_HEADER           string = "Access-Control-Max-Age"
+)
+
+// CORS interface
+type Cors interface {
+	// HandlePreflight Handles the preflight OPTIONS request
+	HandlePreflight(w http.ResponseWriter, r *http.Request)
+	// WriteCorsActualRequestHeaders writes the needed request headers for the CORS support
+	WriteCorsActualRequestHeaders(w http.ResponseWriter)
+}
+
+type cors struct {
+	// Prefix used for the CORS environment variables
+	Prefix string
+
+	log *logging.Logger
+}
+
+// make sure that the cors implements the Cors interface
+var _ Cors = (*cors)(nil)
+
+//Cors constructor
+func New(prefix string, log *logging.Logger) Cors {
+	return cors{Prefix: prefix, log: log}
+}
+
+// HandlePreflight Handles the cors preflight request setting the right headers and responding to the request
+func (c cors) HandlePreflight(w http.ResponseWriter, r *http.Request) {
+	// Check if it has Origin Header
+	hasOrigin := HasOriginHeader(r)
+	if hasOrigin == false {
+		c.log.Info("Invalid CORS preflight request, no Origin header found")
+		writeInvalidPreflightResponse(w)
+		return
+	}
+
+	// Check Access-Control-Request-Method header
+	requestMethodHeader := r.Header.Get(ACCESS_CONTROL_REQUEST_METHOD_HEADER)
+	if isValidAccessControlMethod(requestMethodHeader, c.Prefix, c.log) != true {
+		// Invalid Access Control Method
+		writeInvalidPreflightResponse(w)
+		return
+	}
+
+	// Check Access-Control-Allow-Headers header
+	requestHeadersHeader := r.Header.Get(ACCESS_CONTROL_REQUEST_HEADER_HEADER)
+	if isValidAccessControlHeaders(requestHeadersHeader, c.Prefix, c.log) != true {
+		// Invalid Access Control Header
+		writeInvalidPreflightResponse(w)
+		return
+	}
+
+	writeValidPreflightResponse(w, c)
+}
+
+// HasOriginHeader returns true if the request has Origin header, false otherwise
+func HasOriginHeader(r *http.Request) bool {
+	h := r.Header.Get(ORIGIN_HEADER)
+	if h == "" {
+		return false
+	}
+	return true
+}
+
+// Check if the method name is valid and allowed by the environment variable
+func isValidAccessControlMethod(methodName string, prefix string, log *logging.Logger) bool {
+	if methodName == "" {
+		log.Info(fmt.Sprintf("Invalid Access Control Method for preflight request: '%s'", methodName))
+		return false
+	}
+	allowedMethodsEnv := GetCorsAllowMethods(prefix)
+	allowedMethods := strings.Split(allowedMethodsEnv, ",")
+	log.Debug(fmt.Sprintf("Allowed Methods '%s'", allowedMethods))
+	for i := range allowedMethods {
+		if strings.ToLower(strings.TrimSpace(allowedMethods[i])) == strings.ToLower(strings.TrimSpace(methodName)) {
+			return true
+		}
+	}
+	log.Info(fmt.Sprintf("Invalid Access Control Method for preflight request: '%s'", methodName))
+	return false
+}
+
+// Check if the headers are valid and allowed by the environment variable
+func isValidAccessControlHeaders(headersStr string, prefix string, log *logging.Logger) bool {
+	if headersStr == "" {
+		return true
+	}
+	allowedHeadersEnv := GetCorsAllowHeaders(prefix)
+	allowedHeaders := strings.Split(allowedHeadersEnv, ",")
+
+	// Create a map for faster lookup
+	allowedHeadersMap := make(map[string]struct{}, len(allowedHeaders))
+	for _, s := range allowedHeaders {
+		allowedHeadersMap[strings.ToLower(strings.TrimSpace(s))] = struct{}{}
+	}
+
+	headers := strings.Split(headersStr, ",")
+
+	for i := range headers {
+		_, ok := allowedHeadersMap[strings.ToLower(strings.TrimSpace(headers[i]))]
+		if ok == false {
+			log.Info(fmt.Sprintf("Invalid Access Control Header for preflight request: '%s'", strings.TrimSpace(headers[i])))
+			return false
+		}
+	}
+	return true
+}
+
+// Writes invalid preflight response
+func writeInvalidPreflightResponse(w http.ResponseWriter) {
+	// Write 200 but no CORS header
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}
+
+// Writes valid preflight response
+func writeValidPreflightResponse(w http.ResponseWriter, c cors) {
+	// Write 200 with CORS headers
+	writeCorsPreflightHeaders(w, c)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}
+
+// Writes the CORS preflight request headers (origin and credential)
+func writeCorsPreflightHeaders(w http.ResponseWriter, c cors) {
+	c.WriteCorsActualRequestHeaders(w)
+	w.Header().Set(ACCESS_CONTROL_ALLOW_METHODS_HEADER, GetCorsAllowMethods(c.Prefix))
+	w.Header().Set(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, GetCorsAllowHeaders(c.Prefix))
+	w.Header().Set(ACCESS_CONTROL_EXPOSE_HEADERS_HEADER, GetCorsExposeHeaders(c.Prefix))
+	maxAge := GetCorsMaxAge(c.Prefix)
+	if maxAge != "" {
+		w.Header().Set(ACCESS_CONTROL_MAX_AGE_HEADER, maxAge)
+	}
+}
+
+// Writes the CORS actual request headers (origin and credential)
+func (c cors) WriteCorsActualRequestHeaders(w http.ResponseWriter) {
+	w.Header().Set(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, GetCorsAllowOrigin(c.Prefix))
+	allowCredentials := GetCorsAllowCredentials(c.Prefix)
+	if strings.TrimSpace(allowCredentials) == "true" {
+		w.Header().Set(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, strings.TrimSpace(allowCredentials))
+	}
+}

--- a/trigger/rest_incubator/runtime/cors/cors_test.go
+++ b/trigger/rest_incubator/runtime/cors/cors_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2015 TIBCO Software Inc.
+// All Rights Reserved.
+package cors
+
+import (
+	"github.com/op/go-logging"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+const (
+	TEST_CORS_PREFIX = "FOO_"
+)
+
+var log = logging.MustGetLogger("trigger-tibco-rest")
+
+// Test Has Origin Header method
+func TestHasOriginHeaderOk(t *testing.T) {
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+	// Set Origin
+	r.Header.Set(ORIGIN_HEADER, "http://foo.com")
+
+	hasHeader := HasOriginHeader(r)
+
+	// assert Success
+	assert.Equal(t, true, hasHeader, "Request should have Origin header")
+}
+
+// Test Has Origin Header method
+func TestHasOriginHeaderFalse(t *testing.T) {
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+
+	hasHeader := HasOriginHeader(r)
+
+	// assert Success
+	assert.Equal(t, false, hasHeader, "Request should not have Origin header")
+}
+
+// Test Handle Preflight with no origin header
+func TestHandlePreflightErrorNoOrigin(t *testing.T) {
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+	w := httptest.NewRecorder()
+
+	c := New(TEST_CORS_PREFIX, log)
+	c.HandlePreflight(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Response should have 200 status code")
+
+	assert.Equal(t, 1, len(w.HeaderMap), "Response should have only 1 header")
+
+	assert.Equal(t, "application/json", w.HeaderMap.Get("Content-Type"), "Response should have only 1 header Content-Type")
+}
+
+// Test Handle Preflight with no access control method header
+func TestHandlePreflightErrorNoAccesControlMethod(t *testing.T) {
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+	// Set Origin
+	r.Header.Set(ORIGIN_HEADER, "http://foo.com")
+
+	w := httptest.NewRecorder()
+
+	c := New(TEST_CORS_PREFIX, log)
+	c.HandlePreflight(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Response should have 200 status code")
+
+	assert.Equal(t, 1, len(w.HeaderMap), "Response should have only 1 header")
+
+	assert.Equal(t, "application/json", w.HeaderMap.Get("Content-Type"), "Response should have only 1 header Content-Type")
+}
+
+// Test Handle Preflight with invalid access control method header
+func TestHandlePreflightErrorInvalidAccesControlMethod(t *testing.T) {
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+	// Set Origin
+	r.Header.Set(ORIGIN_HEADER, "http://foo.com")
+	// Set Access Control
+	r.Header.Set(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "foo")
+
+	w := httptest.NewRecorder()
+
+	c := New(TEST_CORS_PREFIX, log)
+	c.HandlePreflight(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Response should have 200 status code")
+
+	assert.Equal(t, 1, len(w.HeaderMap), "Response should have only 1 header")
+
+	assert.Equal(t, "application/json", w.HeaderMap.Get("Content-Type"), "Response should have only 1 header Content-Type")
+}
+
+// Test Handle Preflight with no access control header header
+func TestHandlePreflightErrorInvalidAccesControlHeader(t *testing.T) {
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+	// Set Origin
+	r.Header.Set(ORIGIN_HEADER, "http://foo.com")
+	// Set Access Control
+	r.Header.Set(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "GET")
+	// Set Access Header
+	r.Header.Set(ACCESS_CONTROL_REQUEST_HEADER_HEADER, "foo")
+
+	w := httptest.NewRecorder()
+
+	c := New(TEST_CORS_PREFIX, log)
+	c.HandlePreflight(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Response should have 200 status code")
+
+	assert.Equal(t, 1, len(w.HeaderMap), "Response should have only 1 header")
+
+	assert.Equal(t, "application/json", w.HeaderMap.Get("Content-Type"), "Response should have only 1 header Content-Type")
+}
+
+// Test Handle Preflight ok
+func TestHandlePreflightOkNoAllowCredentialsNorMaxAge(t *testing.T) {
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+	// Set Origin
+	r.Header.Set(ORIGIN_HEADER, "http://foo.com")
+	// Set Access Control
+	r.Header.Set(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "GET")
+	// Set Access Header
+	r.Header.Set(ACCESS_CONTROL_REQUEST_HEADER_HEADER, "Content-Type , Content-Length")
+
+	w := httptest.NewRecorder()
+
+	c := New(TEST_CORS_PREFIX, log)
+	c.HandlePreflight(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Response should have 200 status code")
+
+	// Response should have Access-Control-Allow-Origin header
+	assert.Equal(t, w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), "*", "Response should have star allowOrigin Header")
+	// Response should have Access-Control-Allow-Origin header
+	assert.Equal(t, CORS_ALLOW_METHODS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_METHODS_HEADER), "Response should have methods Header")
+	// Response should have Access-Control-Allow-Headers
+	assert.Equal(t, CORS_ALLOW_HEADERS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), "Response should have headers Header")
+	// Response should have Access-Control-Expose-Headers
+	assert.Equal(t, CORS_EXPOSE_HEADERS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_EXPOSE_HEADERS_HEADER), "Response should have expose headers Header")
+	// Response should not have Access-Control-Allow-Credentials
+	assert.Equal(t, "", w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER), "Response should not have credentials Header")
+	// Response should not have Access-Control-Max-Age
+	assert.Equal(t, "", w.HeaderMap.Get(ACCESS_CONTROL_MAX_AGE_HEADER), "Response should not have max age Header")
+
+}
+
+// Test Handle Preflight ok
+func TestHandlePreflightOkForLowercase(t *testing.T) {
+	// Setup Environment
+	previousCredentials := os.Getenv(TEST_CORS_PREFIX + CORS_ALLOW_CREDENTIALS_KEY)
+	os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_CREDENTIALS_KEY, "true")
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_CREDENTIALS_KEY, previousCredentials)
+
+	previousMaxAge := os.Getenv(TEST_CORS_PREFIX + CORS_MAX_AGE_KEY)
+	os.Setenv(TEST_CORS_PREFIX+CORS_MAX_AGE_KEY, "20")
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_MAX_AGE_KEY, previousMaxAge)
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+	// Set Origin
+	r.Header.Set(ORIGIN_HEADER, "http://foo.com")
+	// Set Access Control
+	r.Header.Set(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "get")
+	// Set Access Header
+	r.Header.Set(ACCESS_CONTROL_REQUEST_HEADER_HEADER, "content-type , content-length")
+
+	w := httptest.NewRecorder()
+
+	c := New(TEST_CORS_PREFIX, log)
+	c.HandlePreflight(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Response should have 200 status code")
+
+	// Response should have Access-Control-Allow-Origin header
+	assert.Equal(t, "*", w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), "Response should have star allowOrigin Header")
+	// Response should have Access-Control-Allow-Origin header
+	assert.Equal(t, CORS_ALLOW_METHODS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_METHODS_HEADER), "Response should have methods Header")
+	// Response should have Access-Control-Allow-Headers
+	assert.Equal(t, CORS_ALLOW_HEADERS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), "Response should have headers Header")
+	// Response should have Access-Control-Expose-Headers
+	assert.Equal(t, CORS_EXPOSE_HEADERS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_EXPOSE_HEADERS_HEADER), "Response should have expose headers Header")
+	// Response should not have Access-Control-Allow-Credentials
+	assert.Equal(t, "true", w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER), "Response should have credentials Header")
+	// Response should not have Access-Control-Max-Age
+	assert.Equal(t, "20", w.HeaderMap.Get(ACCESS_CONTROL_MAX_AGE_HEADER), "Response should have max age Header")
+
+}
+
+// Test Handle Preflight ok
+func TestHandlePreflightOk(t *testing.T) {
+	// Setup Environment
+	previousCredentials := os.Getenv(TEST_CORS_PREFIX + CORS_ALLOW_CREDENTIALS_KEY)
+	os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_CREDENTIALS_KEY, "true")
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_CREDENTIALS_KEY, previousCredentials)
+
+	previousMaxAge := os.Getenv(TEST_CORS_PREFIX + CORS_MAX_AGE_KEY)
+	os.Setenv(TEST_CORS_PREFIX+CORS_MAX_AGE_KEY, "20")
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_MAX_AGE_KEY, previousMaxAge)
+	// Create request
+	r, _ := http.NewRequest("GET", "http://foo.com", nil)
+	// Set Origin
+	r.Header.Set(ORIGIN_HEADER, "http://foo.com")
+	// Set Access Control
+	r.Header.Set(ACCESS_CONTROL_REQUEST_METHOD_HEADER, "GET")
+	// Set Access Header
+	r.Header.Set(ACCESS_CONTROL_REQUEST_HEADER_HEADER, "Content-Type , Content-Length")
+
+	w := httptest.NewRecorder()
+
+	c := New(TEST_CORS_PREFIX, log)
+	c.HandlePreflight(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Response should have 200 status code")
+
+	// Response should have Access-Control-Allow-Origin header
+	assert.Equal(t, "*", w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER), "Response should have star allowOrigin Header")
+	// Response should have Access-Control-Allow-Origin header
+	assert.Equal(t, CORS_ALLOW_METHODS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_METHODS_HEADER), "Response should have methods Header")
+	// Response should have Access-Control-Allow-Headers
+	assert.Equal(t, CORS_ALLOW_HEADERS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_HEADERS_HEADER), "Response should have headers Header")
+	// Response should have Access-Control-Expose-Headers
+	assert.Equal(t, CORS_EXPOSE_HEADERS_DEFAULT, w.HeaderMap.Get(ACCESS_CONTROL_EXPOSE_HEADERS_HEADER), "Response should have expose headers Header")
+	// Response should not have Access-Control-Allow-Credentials
+	assert.Equal(t, "true", w.HeaderMap.Get(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER), "Response should have credentials Header")
+	// Response should not have Access-Control-Max-Age
+	assert.Equal(t, "20", w.HeaderMap.Get(ACCESS_CONTROL_MAX_AGE_HEADER), "Response should have max age Header")
+
+}
+
+func TestIsValidAccessControlMethodOk(t *testing.T) {
+
+	valid := isValidAccessControlMethod("GET", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, true, valid, "GET control method should be valid")
+
+}
+
+func TestIsValidAccessControlMethodFail(t *testing.T) {
+
+	valid := isValidAccessControlMethod("foo", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, false, valid, "foo control method should be in valid")
+
+}
+
+func TestIsValidAccessControlMethodFailEmptyMethod(t *testing.T) {
+
+	valid := isValidAccessControlMethod("", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, false, valid, "empty control method should be in valid")
+
+}
+
+func TestIsValidAccessControlHeadersOk(t *testing.T) {
+
+	valid := isValidAccessControlHeaders("Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, x-requested-with, Accept", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, true, valid, "Headers should be valid")
+
+}
+
+func TestIsValidAccessControlHeadersOkJustOneHeader(t *testing.T) {
+
+	valid := isValidAccessControlHeaders("Content-Type", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, true, valid, "Headers should be valid")
+
+}
+
+func TestIsValidAccessControlHeadersOkJustTwoHeaders(t *testing.T) {
+
+	valid := isValidAccessControlHeaders("Content-Type , Content-Length", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, true, valid, "Headers should be valid")
+
+}
+
+func TestIsValidAccessControlHeadersOkEmptyHeaders(t *testing.T) {
+
+	valid := isValidAccessControlHeaders("", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, true, valid, "Headers should be valid")
+
+}
+
+func TestIsValidAccessControlHeadersFailEmptyHeaders(t *testing.T) {
+
+	valid := isValidAccessControlHeaders(" ", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, false, valid, "Headers should be invalid")
+
+}
+
+func TestIsValidAccessControlHeadersFailInvalidHeaders(t *testing.T) {
+
+	valid := isValidAccessControlHeaders("foo", TEST_CORS_PREFIX, log)
+
+	assert.Equal(t, false, valid, "Headers should be invalid")
+
+}

--- a/trigger/rest_incubator/runtime/cors/environment.go
+++ b/trigger/rest_incubator/runtime/cors/environment.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2015 TIBCO Software Inc.
+// All Rights Reserved.
+
+package cors
+
+import (
+	"os"
+)
+
+// List of constants default values that can be overriden by environment variables
+const (
+	CORS_ALLOW_ORIGIN_KEY          string = "CORS_ALLOW_ORIGIN"
+	CORS_ALLOW_ORIGIN_DEFAULT      string = "*"
+	CORS_ALLOW_METHODS_KEY         string = "CORS_ALLOW_METHODS"
+	CORS_ALLOW_METHODS_DEFAULT     string = "POST, GET, OPTIONS, PUT, DELETE, PATCH"
+	CORS_ALLOW_HEADERS_KEY         string = "CORS_ALLOW_HEADERS"
+	CORS_EXPOSE_HEADERS_KEY        string = "CORS_EXPOSE_HEADERS"
+	CORS_ALLOW_HEADERS_DEFAULT     string = "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, X-Requested-With, Accept, Accept-Language"
+	CORS_EXPOSE_HEADERS_DEFAULT    string = ""
+	CORS_ALLOW_CREDENTIALS_KEY     string = "CORS_ALLOW_CREDENTIALS"
+	CORS_ALLOW_CREDENTIALS_DEFAULT string = "false"
+	CORS_MAX_AGE_KEY               string = "CORS_MAX_AGE"
+	CORS_MAX_AGE_DEFAULT           string = ""
+)
+
+//GetCorsAllowOrigin get the value for CORS 'AllowOrigin' param from environment variable and the default BS_CORS_ALLOW_ORIGIN_DEFAULT will be used if not found
+func GetCorsAllowOrigin(prefix string) string {
+	envalue := os.Getenv(prefix + CORS_ALLOW_ORIGIN_KEY)
+	if envalue == "" {
+		return CORS_ALLOW_ORIGIN_DEFAULT
+	} else {
+		return envalue
+	}
+}
+
+//GetCorsAllowMethods get the allowed method for CORS from environment variable and the default BS_CORS_ALLOW_METHODS_DEFAULT will be used if not found
+func GetCorsAllowMethods(prefix string) string {
+	envalue := os.Getenv(prefix + CORS_ALLOW_METHODS_KEY)
+	if envalue == "" {
+		return CORS_ALLOW_METHODS_DEFAULT
+	} else {
+		return envalue
+	}
+}
+
+//GetCorsAllowHeaders get the value for CORS 'AllowHeaders' param from environment variable and the default BS_CORS_ALLOW_HEADERS_DEFAULT will be used if not found
+func GetCorsAllowHeaders(prefix string) string {
+	envalue := os.Getenv(prefix + CORS_ALLOW_HEADERS_KEY)
+	if envalue == "" {
+		return CORS_ALLOW_HEADERS_DEFAULT
+	} else {
+		return envalue
+	}
+}
+
+//GetCorsExposeHeaders get the value for CORS 'ExposeHeaders' param from environment variable and the default BS_CORS_EXPOSE_HEADERS_DEFAULT will be used if not found
+func GetCorsExposeHeaders(prefix string) string {
+	envalue := os.Getenv(prefix + CORS_EXPOSE_HEADERS_KEY)
+	if envalue == "" {
+		return CORS_EXPOSE_HEADERS_DEFAULT
+	} else {
+		return envalue
+	}
+}
+
+//GetCorsAllowCredentials get the value for CORS 'AllowCredentials' param from environment variable and the default BS_CORS_ALLOW_CREDENTIALS_DEFAULT will be used if not found
+func GetCorsAllowCredentials(prefix string) string {
+	envalue := os.Getenv(prefix + CORS_ALLOW_CREDENTIALS_KEY)
+	if envalue == "" {
+		return CORS_ALLOW_CREDENTIALS_DEFAULT
+	} else {
+		return envalue
+	}
+}
+
+//GetCorsMaxAge get the value for CORS 'Max Age' param from environment variable and the default BS_CORS_ALLOW_CREDENTIALS_DEFAULT will be used if not found
+func GetCorsMaxAge(prefix string) string {
+	envalue := os.Getenv(prefix + CORS_MAX_AGE_KEY)
+	if envalue == "" {
+		return CORS_MAX_AGE_DEFAULT
+	} else {
+		return envalue
+	}
+}

--- a/trigger/rest_incubator/runtime/cors/environment_test.go
+++ b/trigger/rest_incubator/runtime/cors/environment_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2015 TIBCO Software Inc.
+// All Rights Reserved.
+package cors
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+// Test GetCorsAllowOrigin method
+func TestGetCorsAllowOriginOk(t *testing.T) {
+	allowOrigin := GetCorsAllowOrigin(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, CORS_ALLOW_ORIGIN_DEFAULT, allowOrigin, "Allow Origin should be default value")
+}
+
+// Test GetCorsAllowOrigin method
+func TestGetCorsAllowOriginOkModified(t *testing.T) {
+	previous := os.Getenv(TEST_CORS_PREFIX + CORS_ALLOW_ORIGIN_KEY)
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_ORIGIN_KEY, previous)
+
+	newValue := "fooAllowedOrigin"
+
+	// Change value
+	os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_ORIGIN_KEY, newValue)
+
+	allowOrigin := GetCorsAllowOrigin(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, newValue, allowOrigin, "Allow Origin should be "+newValue)
+
+}
+
+// Test GetCorsAllowMethods method
+func TestGetCorsAllowMethodsOk(t *testing.T) {
+	envValue := GetCorsAllowMethods(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, CORS_ALLOW_METHODS_DEFAULT, envValue, "Allow Method should be default value")
+}
+
+// Test GetCorsAllowOrigin method
+func TestGetCorsAllowMethodsOkModified(t *testing.T) {
+	previous := os.Getenv(TEST_CORS_PREFIX + CORS_ALLOW_METHODS_KEY)
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_METHODS_KEY, previous)
+
+	newValue := "fooAllowedMethods"
+
+	// Change value
+	os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_METHODS_KEY, newValue)
+
+	envValue := GetCorsAllowMethods(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, newValue, envValue, "Allow Methods should be "+newValue)
+}
+
+// Test GetCorsAllowHeaders method
+func TestGetCorsAllowHeadersOk(t *testing.T) {
+	envValue := GetCorsAllowHeaders(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, CORS_ALLOW_HEADERS_DEFAULT, envValue, "Allow Headers should be default value")
+}
+
+// Test GetCorsAllowHeaders method
+func TestGetCorsAllowHeadersOkModified(t *testing.T) {
+	previous := os.Getenv(TEST_CORS_PREFIX + CORS_ALLOW_HEADERS_KEY)
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_HEADERS_KEY, previous)
+
+	newValue := "fooAllowedHeaders"
+
+	// Change value
+	os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_HEADERS_KEY, newValue)
+
+	envValue := GetCorsAllowHeaders(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, newValue, envValue, "Allow Headers should be "+newValue)
+}
+
+// Test GetCorsAllowCredentials method
+func TestGetCorsAllowCredentialsOk(t *testing.T) {
+	envValue := GetCorsAllowCredentials(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, CORS_ALLOW_CREDENTIALS_DEFAULT, envValue, "Allow Credentials should be default value")
+}
+
+// Test GetCorsAllowCredentials method
+func TestGetCorsAllowCredentialsOkModified(t *testing.T) {
+	previous := os.Getenv(TEST_CORS_PREFIX + CORS_ALLOW_CREDENTIALS_KEY)
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_CREDENTIALS_KEY, previous)
+
+	newValue := "true"
+
+	// Change value
+	os.Setenv(TEST_CORS_PREFIX+CORS_ALLOW_CREDENTIALS_KEY, newValue)
+
+	envValue := GetCorsAllowCredentials(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, newValue, envValue, "Allow Credentials should be "+newValue)
+}
+
+// Test GetCorsMaxAge method
+func TestGetCorsMaxAgeOk(t *testing.T) {
+	envValue := GetCorsMaxAge(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, CORS_MAX_AGE_DEFAULT, envValue, "Max Age should be default value")
+}
+
+// Test GetCorsAllowCredentials method
+func TestGetCorsMaxAgeOkModified(t *testing.T) {
+	previous := os.Getenv(TEST_CORS_PREFIX + CORS_MAX_AGE_KEY)
+	defer os.Setenv(TEST_CORS_PREFIX+CORS_MAX_AGE_KEY, previous)
+
+	newValue := "21"
+
+	// Change value
+	os.Setenv(TEST_CORS_PREFIX+CORS_MAX_AGE_KEY, newValue)
+
+	envValue := GetCorsMaxAge(TEST_CORS_PREFIX)
+
+	// assert Success
+	assert.Equal(t, newValue, envValue, "Max Age should be "+newValue)
+}

--- a/trigger/rest_incubator/runtime/server.go
+++ b/trigger/rest_incubator/runtime/server.go
@@ -1,0 +1,162 @@
+package rest
+
+import (
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Graceful shutdown HttpServer from: https://github.com/corneldamian/httpway/blob/master/server.go
+
+// NewServer create a new server instance
+//param server - is a instance of http.Server, can be nil and a default one will be created
+func NewServer(addr string, handler http.Handler) *Server {
+	srv := &Server{}
+	srv.Server = &http.Server{Addr: addr, Handler: handler}
+
+	return srv
+}
+
+//Server the server  structure
+type Server struct {
+	*http.Server
+
+	serverInstanceID string
+	listener         net.Listener
+	lastError        error
+	serverGroup      *sync.WaitGroup
+	clientsGroup     chan bool
+}
+
+// InstanceID the server instance id
+func (s *Server) InstanceID() string {
+	return s.serverInstanceID
+}
+
+// Start this will start server
+// command isn't blocking, will exit after run
+func (s *Server) Start() error {
+	if s.Handler == nil {
+		return errors.New("No server handler set")
+	}
+
+	if s.listener != nil {
+		return errors.New("Server already started")
+	}
+
+	addr := s.Addr
+	if addr == "" {
+		addr = ":http"
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	hostname, _ := os.Hostname()
+	s.serverInstanceID = fmt.Sprintf("%x", md5.Sum([]byte(hostname+addr)))
+
+	s.listener = listener
+	s.serverGroup = &sync.WaitGroup{}
+	s.clientsGroup = make(chan bool, 50000)
+
+	//if s.ErrorLog == nil {
+	//    if r, ok := s.Handler.(ishttpwayrouter); ok {
+	//        s.ErrorLog = log.New(&internalServerLoggerWriter{r.(*Router).Logger}, "", 0)
+	//    }
+	//}
+	//
+	s.Handler = &serverHandler{s.Handler, s.clientsGroup, s.serverInstanceID}
+
+	s.serverGroup.Add(1)
+	go func() {
+		defer s.serverGroup.Done()
+
+		err := s.Serve(listener)
+		if err != nil {
+			if strings.Contains(err.Error(), "use of closed network connection") {
+				return
+			}
+
+			s.lastError = err
+		}
+	}()
+
+	return nil
+}
+
+// Stop sends stop command to the server
+func (s *Server) Stop() error {
+	if s.listener == nil {
+		return errors.New("Server not started")
+	}
+
+	if err := s.listener.Close(); err != nil {
+		return err
+	}
+
+	return s.lastError
+}
+
+// IsStarted checks if the server is started
+// will return true even if the server is stopped but there are still some requests to finish
+func (s *Server) IsStarted() bool {
+	if s.listener != nil {
+		return true
+	}
+
+	if len(s.clientsGroup) > 0 {
+		return true
+	}
+
+	return false
+}
+
+// WaitStop waits until server is stopped and all requests are finish
+// timeout - is the time to wait for the requests to finish after the server is stopped
+// will return error if there are still some requests not finished
+func (s *Server) WaitStop(timeout time.Duration) error {
+	if s.listener == nil {
+		return errors.New("Server not started")
+	}
+
+	s.serverGroup.Wait()
+
+	checkClients := time.Tick(100 * time.Millisecond)
+	timeoutTime := time.NewTimer(timeout)
+
+	for {
+		select {
+		case <-checkClients:
+			if len(s.clientsGroup) == 0 {
+				return s.lastError
+			}
+		case <-timeoutTime.C:
+			return fmt.Errorf("WaitStop error, timeout after %s waiting for %d client(s) to finish", timeout, len(s.clientsGroup))
+		}
+	}
+}
+
+type serverHandler struct {
+	handler          http.Handler
+	clientsGroup     chan bool
+	serverInstanceID string
+}
+
+func (sh *serverHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sh.clientsGroup <- true
+	defer func() {
+		<-sh.clientsGroup
+	}()
+
+	w.Header().Add("X-Server-Instance-Id", sh.serverInstanceID)
+
+	sh.handler.ServeHTTP(w, r)
+}

--- a/trigger/rest_incubator/runtime/trigger.go
+++ b/trigger/rest_incubator/runtime/trigger.go
@@ -1,0 +1,219 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/TIBCOSoftware/flogo-contrib/trigger/rest/runtime/cors"
+	"github.com/TIBCOSoftware/flogo-lib/core/action"
+	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
+	"github.com/TIBCOSoftware/flogo-lib/types"
+	"github.com/julienschmidt/httprouter"
+	"github.com/op/go-logging"
+)
+
+const (
+	REST_CORS_PREFIX = "REST_TRIGGER"
+)
+
+// log is the default package logger
+var log = logging.MustGetLogger("trigger-tibco-rest")
+
+var validMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
+
+var md = trigger.NewMetadata(jsonMetadata)
+
+// RestTrigger REST trigger struct
+type RestTrigger struct {
+	Md     *trigger.Metadata
+	runner action.Runner
+	server *Server
+	myId   string
+}
+
+func init() {
+	//	trigger.Register(&RestTrigger{Md: md})
+	trigger.GetRegistry().Add(&RestTrigger{Md: md})
+}
+
+//New Creates a new trigger instance for a given id
+func (t *RestTrigger) New(id string) trigger.Trigger2 {
+	return &RestTrigger{Md: md, myId: id}
+}
+
+// Metadata implements trigger.Trigger.Metadata
+func (t *RestTrigger) Metadata() *trigger.Metadata {
+	return t.Md
+}
+
+func (t *RestTrigger) Init(config types.TriggerConfig, runner action.Runner) {
+	log.Infof("In init, id '%s', Metadata: '%+v', Config: '%+v'", t.myId, t.Md, config)
+	// Parse to trigger.Config
+	var triggerConfig trigger.Config
+	err := json.Unmarshal(config.Data, &triggerConfig)
+	if err != nil {
+		panic(err.Error())
+	}
+	//	triggerConfig := config.Data.(trigger.Config)
+	t.Init2(&triggerConfig, runner)
+}
+
+// Init implements ext.Trigger.Init
+func (t *RestTrigger) Init2(config *trigger.Config, runner action.Runner) {
+
+	router := httprouter.New()
+
+	addr := ":" + config.Settings["port"]
+	t.runner = runner
+
+	endpoints := config.Endpoints
+
+	for _, endpoint := range endpoints {
+
+		if endpointIsValid(endpoint) {
+			method := strings.ToUpper(endpoint.Settings["method"])
+			path := endpoint.Settings["path"]
+
+			log.Infof("REST Trigger: Registering endpoint [%s: %s] for Action: [%s-%s]", method, path, endpoint.ActionType, endpoint.ActionURI)
+
+			router.OPTIONS(path, handleCorsPreflight) // for CORS
+			router.Handle(method, path, newActionHandler(t, endpoint))
+
+		} else {
+			panic(fmt.Sprintf("Invalid endpoint: %v", endpoint))
+		}
+	}
+
+	log.Debugf("REST Trigger: Configured on port %s", config.Settings["port"])
+	t.server = NewServer(addr, router)
+}
+
+// Start implements util.Managed.Start
+func (t *RestTrigger) Start2() error {
+	log.Infof("Start CALLED in Trigger")
+	return nil
+	//	return t.server.Start()
+}
+
+func (t *RestTrigger) Start() error {
+	return t.server.Start()
+}
+
+// Stop implements util.Managed.Stop
+func (t *RestTrigger) Stop() error {
+	return t.server.Stop()
+}
+
+// Handles the cors preflight request
+func handleCorsPreflight(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+
+	log.Infof("Received [OPTIONS] request to CorsPreFlight: %+v", r)
+
+	c := cors.New(REST_CORS_PREFIX, log)
+	c.HandlePreflight(w, r)
+}
+
+// IDResponse id response object
+type IDResponse struct {
+	ID string `json:"id"`
+}
+
+func newActionHandler(rt *RestTrigger, endpoint *trigger.EndpointConfig) httprouter.Handle {
+
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+
+		log.Infof("REST Trigger: Received request for id '%s'", rt.myId)
+
+		c := cors.New(REST_CORS_PREFIX, log)
+		c.WriteCorsActualRequestHeaders(w)
+
+		pathParams := make(map[string]string)
+		for _, param := range ps {
+			pathParams[param.Key] = param.Value
+		}
+
+		var content interface{}
+		err := json.NewDecoder(r.Body).Decode(&content)
+		if err != nil {
+			switch {
+			case err == io.EOF:
+			// empty body
+			//todo should endpoint say if content is expected?
+			case err != nil:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
+		queryValues := r.URL.Query()
+		queryParams := make(map[string]string, len(queryValues))
+
+		for key, value := range queryValues {
+			queryParams[key] = strings.Join(value, ",")
+		}
+
+		data := map[string]interface{}{
+			"params":      pathParams,
+			"pathParams":  pathParams,
+			"queryParams": queryParams,
+			"content":     content,
+		}
+
+		//todo handle error
+		startAttrs, _ := rt.Md.OutputsToAttrs(data, false)
+
+		action := action.GetRegistry().GetAction(endpoint.ActionId)
+		log.Infof("Found action' %+x'",action) 
+		
+
+		context := trigger.NewContext(context.Background(), startAttrs)
+		replyCode, replyData, err := rt.runner.Run(context, action, endpoint.ActionURI, nil)
+
+		if err != nil {
+			log.Debugf("REST Trigger Error: %s", err.Error())
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if replyData != nil {
+			w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+			w.WriteHeader(replyCode)
+			if err := json.NewEncoder(w).Encode(replyData); err != nil {
+				log.Error(err)
+			}
+		}
+
+		if replyCode > 0 {
+			w.WriteHeader(replyCode)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Utils
+
+func endpointIsValid(endpoint *trigger.EndpointConfig) bool {
+
+	if !stringInList(strings.ToUpper(endpoint.Settings["method"]), validMethods) {
+		return false
+	}
+
+	//validate path
+
+	return true
+}
+
+func stringInList(str string, list []string) bool {
+	for _, value := range list {
+		if value == str {
+			return true
+		}
+	}
+	return false
+}

--- a/trigger/rest_incubator/runtime/trigger_metadata.go
+++ b/trigger/rest_incubator/runtime/trigger_metadata.go
@@ -1,0 +1,51 @@
+package rest
+
+var jsonMetadata = `{
+  "name": "tibco-rest",
+  "version": "0.0.1",
+  "description": "Simple REST trigger",
+  "settings": [
+    {
+      "name": "port",
+      "type": "integer"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "params",
+      "type": "params"
+    },
+    {
+      "name": "pathParams",
+      "type": "params"
+    },
+    {
+      "name": "queryParams",
+      "type": "params"
+    },
+    {
+      "name": "content",
+      "type": "object"
+    }
+  ],
+  "endpoint": {
+    "settings": [
+      {
+        "name": "method",
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "type": "string"
+      },
+      {
+        "name": "autoIdReply",
+        "type": "boolean"
+      },
+      {
+        "name": "useReplyHandler",
+        "type": "boolean"
+      }
+    ]
+  }
+}`

--- a/trigger/rest_incubator/runtime/trigger_test.go
+++ b/trigger/rest_incubator/runtime/trigger_test.go
@@ -1,0 +1,82 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/action"
+	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
+)
+
+const testConfig string = `{
+  "name": "tibco-rest",
+  "settings": {
+    "port": "8091"
+  },
+  "endpoints": [
+    {
+      "flowURI": "local://testFlow",
+      "settings": {
+        "method": "POST",
+        "path": "/device/:id/reset"
+      }
+    }
+  ]
+}
+`
+
+type TestRunner struct {
+}
+
+// Run implements action.Runner.Run
+func (tr *TestRunner) Run(context context.Context, action action.Action, uri string, options interface{}) (code int, data interface{}, err error) {
+	log.Debugf("Ran Action: %v", uri)
+	return 0, nil, nil
+}
+
+func TestRegistered(t *testing.T) {
+	tgr := trigger.Get("tibco-rest")
+
+	if tgr == nil {
+		t.Error("Trigger Not Registered")
+		t.Fail()
+		return
+	}
+}
+
+func TestInit(t *testing.T) {
+	tgr := trigger.Get("tibco-rest")
+
+	runner := &TestRunner{}
+
+	config := &trigger.Config{}
+	json.Unmarshal([]byte(testConfig), config)
+	tgr.Init(config, runner)
+}
+
+func TestEndpoint(t *testing.T) {
+
+	tgr := trigger.Get("tibco-rest")
+
+	tgr.Start()
+	defer tgr.Stop()
+
+	uri := "http://127.0.0.1:8091/device/12345/reset"
+
+	req, err := http.NewRequest("POST", uri, nil)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	log.Debug("response Status:", resp.Status)
+
+	if resp.StatusCode >= 300 {
+		t.Fail()
+	}
+}

--- a/trigger/rest_incubator/trigger.json
+++ b/trigger/rest_incubator/trigger.json
@@ -1,0 +1,54 @@
+{
+  "name": "tibco-rest",
+  "version": "0.0.1",
+  "title": "Receive HTTP Message",
+  "description": "Simple REST Trigger",
+  "settings": [
+    {
+      "name": "port",
+      "type": "integer",
+      "required": true
+    }
+  ],
+  "outputs": [
+    {
+      "name": "params",
+      "type": "params"
+    },
+    {
+      "name": "pathParams",
+      "type": "params"
+    },
+    {
+      "name": "queryParams",
+      "type": "params"
+    },
+    {
+      "name": "content",
+      "type": "object"
+    }
+  ],
+  "endpoint": {
+    "settings": [
+      {
+        "name": "method",
+        "type": "string",
+        "required" : true,
+        "allowed" : ["GET", "POST", "PUT", "PATCH", "DELETE"]
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "required" : true
+      },
+      {
+        "name": "autoIdReply",
+        "type": "boolean"
+      },
+      {
+        "name": "useReplyHandler",
+        "type": "boolean"
+      }
+    ]
+  }
+}

--- a/trigger/rest_incubator/ui/package.json
+++ b/trigger/rest_incubator/ui/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "tibco-rest",
+  "version": "0.0.1",
+  "description": "Simple REST trigger"
+}

--- a/trigger/rest_incubator/ui/trigger.json
+++ b/trigger/rest_incubator/ui/trigger.json
@@ -1,0 +1,55 @@
+{
+  "name": "tibco-rest",
+  "version": "0.0.1",
+  "title": "Receive HTTP Message",
+  "description": "Simple REST Trigger",
+  "homepage": "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/rest",
+  "settings": [
+    {
+      "name": "port",
+      "type": "integer",
+      "required": true
+    }
+  ],
+  "outputs": [
+    {
+      "name": "params",
+      "type": "params"
+    },
+    {
+      "name": "pathParams",
+      "type": "params"
+    },
+    {
+      "name": "queryParams",
+      "type": "params"
+    },
+    {
+      "name": "content",
+      "type": "object"
+    }
+  ],
+  "endpoint": {
+    "settings": [
+      {
+        "name": "method",
+        "type": "string",
+        "required" : true,
+        "allowed" : ["GET", "POST", "PUT", "PATCH", "DELETE"]
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "required" : true
+      },
+      {
+        "name": "autoIdReply",
+        "type": "boolean"
+      },
+      {
+        "name": "useReplyHandler",
+        "type": "boolean"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This creates the new trigger implementation needed for the new engine. 

It should not be used until the full app.json implementation has been finished