### PR TITLE
Enhanced log message

### DIFF
--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -816,6 +816,9 @@ func (td *TaskData) EvalActivity() (done bool, evalErr error) {
 				done = false
 			}
 		}
+		if evalErr != nil {
+			logger.Errorf("Execution failed for Activity[%s] in Flow[%s] - %s", td.task.Name(), td.taskEnv.Instance.Name(), evalErr.Error())
+		}
 	}()
 
 	done, evalErr = act.Eval(td)


### PR DESCRIPTION
It would be better to include flow name in the log so that users can easily locate failing activity.
By just looking at logs, there is no easy way for users to find which activity is failing.

e.g. 2017-05-02 18:14:29.728 ERROR  [engine] - Execution failed for Activity[restinvoke] in Flow[F1] - Required path parameter [id] is not configured.
 