### PR TITLE
Feature/kafkapub

### DIFF
--- a/activity/kafkapub/README.md
+++ b/activity/kafkapub/README.md
@@ -1,4 +1,4 @@
-# tibco-twilio
+# tibco-kafkapub
 This activity provides your flogo application the ability to send a Kafka message
 
 
@@ -75,7 +75,7 @@ Configure a task to send the time of day to the 'syslog' topic
 {
   "id": 3,
   "type": 1,
-  "activityType": "tibco-twilio",
+  "activityType": "tibco-kafkapub",
   "name": "Send Text Message",
   "attributes": [
     { "name": "accountSID", "value": "A...9" },
@@ -94,7 +94,7 @@ Configure a task in flow to send 'my text message' to a number from a REST trigg
 {
   "id": 3,
   "type": 1,
-  "activityType": "tibco-twilio",
+  "activityType": "tibco-kafkapub",
   "name": "Send Text Message",
   "attributes": [
     { "name": "accountSID", "value": "A...9" },

--- a/activity/kafkapub/README.md
+++ b/activity/kafkapub/README.md
@@ -79,7 +79,7 @@ Configure a task to send a message to the 'syslog' topic.
       "description": "Publish a message to a kafka topic",
       "type": 1,
       "activityType": "tibco-kafkapub",
-      "activityRef": "github.com/wnichols/flogo-contrib/activity/kafkapub",
+      "activityRef": "github.com/TIBCOSoftware/flogo-contrib/activity/kafkapub",
       "attributes": [
         {
           "name": "BrokerUrls",

--- a/activity/kafkapub/README.md
+++ b/activity/kafkapub/README.md
@@ -1,0 +1,109 @@
+# tibco-twilio
+This activity provides your flogo application the ability to send a Kafka message
+
+
+## Installation
+
+```bash
+flogo add activity github.com/TIBCOSoftware/flogo-contrib/activity/kafkapub
+```
+
+## Schema
+Inputs and Outputs:
+
+```json
+{
+ "inputs":[
+    {
+      "name": "BrokerUrls",
+      "type": "string"
+    },
+    {
+      "name": "Topic",
+      "type": "string"
+    },
+    {
+      "name": "Message",
+      "type": "string"
+    },
+    {
+      "name": "user",
+      "type": "string"
+    },
+    {
+      "name": "password",
+      "type": "string"
+    },
+    {
+      "name": "truststore",
+      "type": "string"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "partition",
+      "type": "int"
+    },
+    {
+      "name": "offset",
+      "type": "long"
+    }
+  ]
+}
+```
+## Settings
+| Setting     | Description    | Cardinality |
+|:------------|:---------------|--------------|
+| BrokerUrls | The Kafka cluster to connect to |Required|         
+| Token  | The Kafka topic on which to place the message  |Required|
+| Message       | The text message to send |Required|
+| user  | If connectiong to a SASL enabled port, the userid to use for authentication | Optional|
+| password  | If connectiong to a SASL enabled port, the password to use for authentication | Optional|
+| truststore  | If connectiong to a TLS secured port, the directory containing the certificates representing the trust chain for the connection.  This is usually just the CACert used to sign the server's certificate | Optional|
+
+## Outputs
+| Value     | Description    |
+|:------------|:---------------|
+| partition | Documents the partition that the message was placed on |
+| offset | Documents the offset for the message |
+
+## Configuration Examples
+### Simple
+Configure a task to send the time of day to the 'syslog' topic
+//TODO
+```json
+{
+  "id": 3,
+  "type": 1,
+  "activityType": "tibco-twilio",
+  "name": "Send Text Message",
+  "attributes": [
+    { "name": "accountSID", "value": "A...9" },
+    { "name": "authToken", "value": "A...9" },
+    { "name": "from", "value": "+12016901385" },
+    { "name": "to", "value": "+16175555555" },
+    { "name": "message", "value": "my text message" }
+  ]
+}
+```
+
+### Advanced
+Configure a task in flow to send 'my text message' to a number from a REST trigger's query parameter:
+
+```json
+{
+  "id": 3,
+  "type": 1,
+  "activityType": "tibco-twilio",
+  "name": "Send Text Message",
+  "attributes": [
+    { "name": "accountSID", "value": "A...9" },
+    { "name": "authToken", "value": "A...9" },
+    { "name": "from", "value": "+12016901385" },
+    { "name": "message", "value": "my text message" }
+  ],
+  "inputMappings": [
+    { "type": 1, "value": "[T.queryParams].From", "mapTo": "to" }
+  ]
+}
+```

--- a/activity/kafkapub/README.md
+++ b/activity/kafkapub/README.md
@@ -52,58 +52,54 @@ Inputs and Outputs:
 }
 ```
 ## Settings
-| Setting     | Description    | Cardinality |
-|:------------|:---------------|--------------|
-| BrokerUrls | The Kafka cluster to connect to |Required|         
-| Token  | The Kafka topic on which to place the message  |Required|
-| Message       | The text message to send |Required|
-| user  | If connectiong to a SASL enabled port, the userid to use for authentication | Optional|
-| password  | If connectiong to a SASL enabled port, the password to use for authentication | Optional|
-| truststore  | If connectiong to a TLS secured port, the directory containing the certificates representing the trust chain for the connection.  This is usually just the CACert used to sign the server's certificate | Optional|
+| Setting    | Description                                                                                                                                                                                             | Cardinality |
+|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| BrokerUrls | The Kafka cluster to connect to                                                                                                                                                                         | Required    |
+| Token      | The Kafka topic on which to place the message                                                                                                                                                           | Required    |
+| Message    | The text message to send                                                                                                                                                                                | Required    |
+| user       | If connectiong to a SASL enabled port, the userid to use for authentication                                                                                                                             | Optional    |
+| password   | If connectiong to a SASL enabled port, the password to use for authentication                                                                                                                           | Optional    |
+| truststore | If connectiong to a TLS secured port, the directory containing the certificates representing the trust chain for the connection.  This is usually just the CACert used to sign the server's certificate | Optional    |
 
 ## Outputs
-| Value     | Description    |
-|:------------|:---------------|
+| Value     | Description                                            |
+|-----------|--------------------------------------------------------|
 | partition | Documents the partition that the message was placed on |
-| offset | Documents the offset for the message |
+| offset    | Documents the offset for the message                   |
 
 ## Configuration Examples
 ### Simple
-Configure a task to send the time of day to the 'syslog' topic
-//TODO
-```json
-{
-  "id": 3,
-  "type": 1,
-  "activityType": "tibco-kafkapub",
-  "name": "Send Text Message",
-  "attributes": [
-    { "name": "accountSID", "value": "A...9" },
-    { "name": "authToken", "value": "A...9" },
-    { "name": "from", "value": "+12016901385" },
-    { "name": "to", "value": "+16175555555" },
-    { "name": "message", "value": "my text message" }
-  ]
-}
-```
+Configure a task to send a message to the 'syslog' topic.
 
-### Advanced
-Configure a task in flow to send 'my text message' to a number from a REST trigger's query parameter:
 
 ```json
 {
-  "id": 3,
-  "type": 1,
-  "activityType": "tibco-kafkapub",
-  "name": "Send Text Message",
-  "attributes": [
-    { "name": "accountSID", "value": "A...9" },
-    { "name": "authToken", "value": "A...9" },
-    { "name": "from", "value": "+12016901385" },
-    { "name": "message", "value": "my text message" }
-  ],
-  "inputMappings": [
-    { "type": 1, "value": "[T.queryParams].From", "mapTo": "to" }
-  ]
+      "id": 2,
+      "name": "tibco-kafkapub",
+      "description": "Publish a message to a kafka topic",
+      "type": 1,
+      "activityType": "tibco-kafkapub",
+      "activityRef": "github.com/wnichols/flogo-contrib/activity/kafkapub",
+      "attributes": [
+        {
+          "name": "BrokerUrls",
+          "value": "bilbo:9092",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Topic",
+          "value": "syslog",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Message",
+          "value": "mary had a little lamb",
+          "required": false,
+          "type": "string"
+        }
+      ]
 }
 ```
+

--- a/activity/kafkapub/README.md
+++ b/activity/kafkapub/README.md
@@ -5,7 +5,7 @@ This activity provides your flogo application the ability to send a Kafka messag
 ## Installation
 
 ```bash
-flogo add activity github.com/TIBCOSoftware/flogo-contrib/activity/kafkapub
+flogo install github.com/TIBCOSoftware/flogo-contrib/activity/kafkapub
 ```
 
 ## Schema

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -1,0 +1,171 @@
+package kafkapub
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	"github.com/TIBCOSoftware/flogo-lib/core/activity"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+)
+
+// log is the default package logger
+var flogoLogger = logger.GetLogger("activity-tibco-kafkapub")
+
+// MyActivity is a stub for your Activity implementation
+type KafkaPubActivity struct {
+	metadata     *activity.Metadata
+	kafkaConfig  *sarama.Config
+	brokers      []string
+	topic        string
+	syncProducer sarama.SyncProducer
+}
+
+// NewActivity creates a new activity
+func NewActivity(metadata *activity.Metadata) activity.Activity {
+	return &KafkaPubActivity{metadata: metadata}
+}
+
+// Metadata implements activity.Activity.Metadata
+func (a *KafkaPubActivity) Metadata() *activity.Metadata {
+	return a.metadata
+}
+
+// Eval implements activity.Activity.Eval
+func (a *KafkaPubActivity) Eval(context activity.Context) (done bool, err error) {
+	err = initParms(a, context)
+	if err != nil {
+		flogoLogger.Errorf("Kafkapub parameters initialization got error: [%s]", err)
+		return false, err
+	}
+	defer func() {
+		if err := a.syncProducer.Close(); err != nil {
+			panic(err)
+		}
+	}()
+	if context.GetInput("Message") != nil {
+		msg := &sarama.ProducerMessage{
+			Topic: a.topic,
+			Value: sarama.StringEncoder(context.GetInput("Message").(string)),
+		}
+		partition, offset, err := a.syncProducer.SendMessage(msg)
+		if err != nil {
+			return false, fmt.Errorf("kafkapub failed to send message for reason [%s]", err)
+		}
+		context.SetOutput("partition", partition)
+		context.SetOutput("offset", offset)
+		flogoLogger.Debugf("Kafkapub message [%s] sent successfully on partition [%d] and offset [%d]",
+			context.GetInput("Message").(string), partition, offset)
+		return true, nil
+	}
+	return false, fmt.Errorf("kafkapub called without a message to publish")
+}
+
+func initParms(a *KafkaPubActivity, context activity.Context) error {
+	if context.GetInput("BrokerUrls") != nil {
+		a.kafkaConfig = sarama.NewConfig()
+		a.kafkaConfig.Producer.Return.Errors = true
+		a.kafkaConfig.Producer.RequiredAcks = sarama.WaitForAll
+		a.kafkaConfig.Producer.Retry.Max = 5
+		a.kafkaConfig.Producer.Return.Successes = true
+		brokerUrls := strings.Split(context.GetInput("BrokerUrls").(string), ",")
+		brokers := make([]string, len(brokerUrls))
+		for brokerNo, broker := range brokerUrls {
+			_, error := url.Parse(broker)
+			if error != nil {
+				return fmt.Errorf("BrokerUrl [%s] format invalid for reason: [%s]", broker, error.Error())
+			}
+			brokers[brokerNo] = broker
+		}
+		a.brokers = brokers
+		flogoLogger.Debugf("Kafkapub brokers [%v]", brokers)
+	} else {
+		return fmt.Errorf("Kafkapub activity is not configured with at least one BrokerUrl")
+	}
+	if context.GetInput("Topic") != nil {
+		a.topic = context.GetInput("Topic").(string)
+		flogoLogger.Debugf("Kafkapub topic [%s]", a.topic)
+	} else {
+		return fmt.Errorf("Topic input parameter not provided and is required")
+	}
+
+	//clientKeystore
+	/*
+		Its worth mentioning here that when the keystore for kafka is created it must support RSA keys via
+		the -keyalg RSA option.  If not then there will be ZERO overlap in supported cipher suites with java.
+		see:   https://issues.apache.org/jira/browse/KAFKA-3647
+		for more info
+	*/
+	if context.GetInput("truststore") != nil {
+		trustStore := context.GetInput("truststore")
+		if trustStore != nil && len(trustStore.(string)) > 0 {
+			trustPool, err := getCerts(trustStore.(string))
+			if err != nil {
+				return err
+			}
+			config := tls.Config{
+				RootCAs:            trustPool,
+				InsecureSkipVerify: true}
+			a.kafkaConfig.Net.TLS.Enable = true
+			a.kafkaConfig.Net.TLS.Config = &config
+		}
+		flogoLogger.Debugf("Kafkapub initialized truststore from [%s]", trustStore)
+	}
+	// SASL
+	if context.GetInput("user") != nil {
+		var password string
+		user := context.GetInput("user").(string)
+		if context.GetInput("password") != nil {
+			password = context.GetInput("password").(string)
+		}
+		a.kafkaConfig.Net.SASL.Enable = true
+		a.kafkaConfig.Net.SASL.User = user
+		a.kafkaConfig.Net.SASL.Password = password
+		flogoLogger.Debugf("Kafkapub SASL parms initialized; user [%s]  password[########]", user)
+	}
+
+	syncProducer, err := sarama.NewSyncProducer(a.brokers, a.kafkaConfig)
+	if err != nil {
+		return fmt.Errorf("Kafkapub failed to create a SyncProducer.  Check any TLS or SASL parameters carefully.  Reason given: [%s]", err)
+	}
+	a.syncProducer = syncProducer
+
+	flogoLogger.Debug("Kafkapub synchronous producer created")
+	return nil
+}
+
+func getCerts(trustStore string) (*x509.CertPool, error) {
+	certPool := x509.NewCertPool()
+	fileInfo, err := os.Stat(trustStore)
+	if err != nil {
+		return certPool, fmt.Errorf("Truststore [%s] does not exist", trustStore)
+	}
+	switch mode := fileInfo.Mode(); {
+	case mode.IsDir():
+		break
+	case mode.IsRegular():
+		return certPool, fmt.Errorf("Truststore [%s] is not a directory.  Must be a directory containing trusted certificates in PEM format",
+			trustStore)
+	}
+	trustedCertFiles, err := ioutil.ReadDir(trustStore)
+	if err != nil || len(trustedCertFiles) == 0 {
+		return certPool, fmt.Errorf("Failed to read trusted certificates from [%s]  Must be a directory containing trusted certificates in PEM format", trustStore)
+	}
+	for _, trustCertFile := range trustedCertFiles {
+		fqfName := fmt.Sprintf("%s%c%s", trustStore, os.PathSeparator, trustCertFile.Name())
+		trustCertBytes, err := ioutil.ReadFile(fqfName)
+		if err != nil {
+			flogoLogger.Warnf("Failed to read trusted certificate [%s] ... continuing", trustCertFile.Name())
+		}
+		certPool.AppendCertsFromPEM(trustCertBytes)
+	}
+	if len(certPool.Subjects()) < 1 {
+		return certPool, fmt.Errorf("Failed to read trusted certificates from [%s]  After processing all files in the directory no valid trusted certs were found", trustStore)
+	}
+	return certPool, nil
+}

--- a/activity/kafkapub/activity.json
+++ b/activity/kafkapub/activity.json
@@ -1,0 +1,44 @@
+{
+  "name": "tibco-kafkapub",
+  "version": "0.0.1",
+  "type": "flogo:activity",
+  "ref": "github.com/wnichols/flogo-contrib/activity/kafkapub",
+  "description": "Publish a message to a kafka topic",
+  "author": "Wendell Nichols <wnichols@tibco.com>",
+  "inputs":[
+    {
+      "name": "BrokerUrls",
+      "type": "string"
+    },
+    {
+      "name": "Topic",
+      "type": "string"
+    },
+    {
+      "name": "Message",
+      "type": "string"
+    },
+    {
+      "name": "user",
+      "type": "string"
+    },
+    {
+      "name": "password",
+      "type": "string"
+    },
+    {
+      "name": "truststore",
+      "type": "string"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "partition",
+      "type": "int"
+    },
+    {
+      "name": "offset",
+      "type": "long"
+    }
+  ]
+}

--- a/activity/kafkapub/activity.json
+++ b/activity/kafkapub/activity.json
@@ -2,7 +2,7 @@
   "name": "tibco-kafkapub",
   "version": "0.0.1",
   "type": "flogo:activity",
-  "ref": "github.com/wnichols/flogo-contrib/activity/kafkapub",
+  "ref": "github.com/TIBCOSoftware/flogo-contrib/activity/kafkapub",
   "description": "Publish a message to a kafka topic",
   "author": "Wendell Nichols <wnichols@tibco.com>",
   "inputs":[

--- a/activity/kafkapub/activity_test.go
+++ b/activity/kafkapub/activity_test.go
@@ -9,6 +9,35 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/flow/test"
 )
 
+/*
+The setup for the kafka server used to run these tests:
+section from server.properties:
+	listeners=PLAINTEXT://cheetah.na.tibco.com:9092,SSL://cheetah:9093,SASL_PLAINTEXT://cheetah:9094,SASL_SSL://cheetah.com:9095
+
+	sasl.enabled.mechanisms=PLAIN
+	sasl.mechanism.inter.broker.protocol=PLAIN
+
+	ssl.keystore.location=/opt/kafka_2.12-0.10.2.1/keys/kafka.jks
+	ssl.keystore.password=sauron
+	ssl.key.password=sauron
+	ssl.truststore.location=/opt/kafka_2.12-0.10.2.1/keys/kafka.jks
+	ssl.truststore.password=sauron
+	ssl.client.auth=none
+	ssl.enabled.protocols=TLSv1.2,TLSv1.1,TLSv1
+
+	advertised.listeners=PLAINTEXT://cheetah.na.tibco.com:9092,SSL://cheetah:9093,SASL_PLAINTEXT://cheetah:9094,SASL_SSL://cheetah:9095
+
+The SASL file:
+	KafkaServer {
+	org.apache.kafka.common.security.plain.PlainLoginModule required
+	username="admin"
+	password="admin"
+	user_wcn00="sauron"
+	user_alice="sissy";
+	};
+To get kafka to pick up the jaas file add a vm parm like:
+	-Djava.security.auth.login.config=/local/opt/kafka/kafka_2.11-0.10.2.0/config/kafka_server_jaas.conf
+*/
 var activityMetadata *activity.Metadata
 
 func getActivityMetadata() *activity.Metadata {
@@ -48,7 +77,7 @@ func TestPlain(t *testing.T) {
 	tc := test.NewTestActivityContext(getActivityMetadata())
 
 	//setup attrs
-	tc.SetInput("BrokerUrls", "bilbo:9092")
+	tc.SetInput("BrokerUrls", "cheetah:9092")
 	tc.SetInput("Topic", "syslog")
 	tc.SetInput("Message", "######### PLAIN ###########  Mary had a little lamb, its fleece was white as snow.")
 	act.Eval(tc)
@@ -68,7 +97,7 @@ func TestSSL(t *testing.T) {
 	tc := test.NewTestActivityContext(getActivityMetadata())
 
 	//setup attrs
-	tc.SetInput("BrokerUrls", "bilbo:9093")
+	tc.SetInput("BrokerUrls", "cheetah:9093")
 	tc.SetInput("Topic", "syslog")
 	tc.SetInput("truststore", "/opt/kafka/kafka_2.11-0.10.2.0/keys/trust")
 	tc.SetInput("Message", "######### TLS ###########  Mary had a little lamb, its fleece was white as snow.")
@@ -89,7 +118,7 @@ func TestSASL_PLAIN(t *testing.T) {
 	tc := test.NewTestActivityContext(getActivityMetadata())
 
 	//setup attrs
-	tc.SetInput("BrokerUrls", "bilbo:9094")
+	tc.SetInput("BrokerUrls", "cheetah:9094")
 	tc.SetInput("Topic", "syslog")
 	tc.SetInput("user", "wcn00")
 	tc.SetInput("password", "sauron")
@@ -111,7 +140,7 @@ func TestSASL_TLS(t *testing.T) {
 	tc := test.NewTestActivityContext(getActivityMetadata())
 
 	//setup attrs
-	tc.SetInput("BrokerUrls", "bilbo:9095")
+	tc.SetInput("BrokerUrls", "cheetah:9095")
 	tc.SetInput("truststore", "/opt/kafka/kafka_2.11-0.10.2.0/keys/trust")
 	tc.SetInput("Topic", "syslog")
 	tc.SetInput("user", "wcn00")

--- a/activity/kafkapub/activity_test.go
+++ b/activity/kafkapub/activity_test.go
@@ -1,0 +1,122 @@
+package kafkapub
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/activity"
+	"github.com/TIBCOSoftware/flogo-lib/flow/test"
+)
+
+var activityMetadata *activity.Metadata
+
+func getActivityMetadata() *activity.Metadata {
+
+	if activityMetadata == nil {
+		jsonMetadataBytes, err := ioutil.ReadFile("activity.json")
+		if err != nil {
+			panic("No Json Metadata found for activity.json path")
+		}
+
+		activityMetadata = activity.NewMetadata(string(jsonMetadataBytes))
+	}
+
+	return activityMetadata
+}
+
+func TestCreate(t *testing.T) {
+	act := NewActivity(getActivityMetadata())
+	if act == nil {
+		t.Error("Activity Not Created")
+		t.Fail()
+		return
+	}
+	log.Println("TestCreate successfull")
+}
+
+func TestPlain(t *testing.T) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Failed()
+			t.Errorf("panic during execution: %v", r)
+		}
+	}()
+
+	act := NewActivity(getActivityMetadata())
+	tc := test.NewTestActivityContext(getActivityMetadata())
+
+	//setup attrs
+	tc.SetInput("BrokerUrls", "bilbo:9092")
+	tc.SetInput("Topic", "syslog")
+	tc.SetInput("Message", "######### PLAIN ###########  Mary had a little lamb, its fleece was white as snow.")
+	act.Eval(tc)
+	log.Printf("TestEval successfull.  partition [%d]  offset [%d]", tc.GetOutput("partition"), tc.GetOutput("offset"))
+}
+
+func TestSSL(t *testing.T) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Failed()
+			t.Errorf("panic during execution: %v", r)
+		}
+	}()
+
+	act := NewActivity(getActivityMetadata())
+	tc := test.NewTestActivityContext(getActivityMetadata())
+
+	//setup attrs
+	tc.SetInput("BrokerUrls", "bilbo:9093")
+	tc.SetInput("Topic", "syslog")
+	tc.SetInput("truststore", "/opt/kafka/kafka_2.11-0.10.2.0/keys/trust")
+	tc.SetInput("Message", "######### TLS ###########  Mary had a little lamb, its fleece was white as snow.")
+	act.Eval(tc)
+	log.Printf("TestEval successfull.  partition [%d]  offset [%d]", tc.GetOutput("partition"), tc.GetOutput("offset"))
+}
+
+func TestSASL_PLAIN(t *testing.T) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Failed()
+			t.Errorf("panic during execution: %v", r)
+		}
+	}()
+
+	act := NewActivity(getActivityMetadata())
+	tc := test.NewTestActivityContext(getActivityMetadata())
+
+	//setup attrs
+	tc.SetInput("BrokerUrls", "bilbo:9094")
+	tc.SetInput("Topic", "syslog")
+	tc.SetInput("user", "wcn00")
+	tc.SetInput("password", "sauron")
+	tc.SetInput("Message", "######### SASL_PLAIN ###########  Mary had a little lamb, its fleece was white as snow.")
+	act.Eval(tc)
+	log.Printf("TestEval successfull.  partition [%d]  offset [%d]", tc.GetOutput("partition"), tc.GetOutput("offset"))
+}
+
+func TestSASL_TLS(t *testing.T) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Failed()
+			t.Errorf("panic during execution: %v", r)
+		}
+	}()
+
+	act := NewActivity(getActivityMetadata())
+	tc := test.NewTestActivityContext(getActivityMetadata())
+
+	//setup attrs
+	tc.SetInput("BrokerUrls", "bilbo:9095")
+	tc.SetInput("truststore", "/opt/kafka/kafka_2.11-0.10.2.0/keys/trust")
+	tc.SetInput("Topic", "syslog")
+	tc.SetInput("user", "wcn00")
+	tc.SetInput("password", "sauron")
+	tc.SetInput("Message", "######### SASL_TLS ###########  Mary had a little lamb, its fleece was white as snow.")
+	act.Eval(tc)
+	log.Printf("TestEval successfull.  partition [%d]  offset [%d]", tc.GetOutput("partition"), tc.GetOutput("offset"))
+}

--- a/activity/kafkapub/ui/activity.json
+++ b/activity/kafkapub/ui/activity.json
@@ -1,0 +1,44 @@
+{
+  "name": "tibco-kafkapub",
+  "version": "0.0.1",
+  "type": "flogo:activity",
+  "ref": "github.com/wnichols/flogo-contrib/activity/kafkapub",
+  "description": "Publish a message to a kafka topic",
+  "author": "Wendell Nichols <wnichols@tibco.com>",
+  "inputs":[
+    {
+      "name": "BrokerUrls",
+      "type": "string"
+    },
+    {
+      "name": "Topic",
+      "type": "string"
+    },
+    {
+      "name": "Message",
+      "type": "string"
+    },
+    {
+      "name": "user",
+      "type": "string"
+    },
+    {
+      "name": "password",
+      "type": "string"
+    },
+    {
+      "name": "truststore",
+      "type": "string"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "partition",
+      "type": "int"
+    },
+    {
+      "name": "offset",
+      "type": "long"
+    }
+  ]
+}

--- a/activity/kafkapub/ui/activity.json
+++ b/activity/kafkapub/ui/activity.json
@@ -2,7 +2,7 @@
   "name": "tibco-kafkapub",
   "version": "0.0.1",
   "type": "flogo:activity",
-  "ref": "github.com/wnichols/flogo-contrib/activity/kafkapub",
+  "ref": "github.com/TIBCOSoftware/flogo-contrib/activity/kafkapub",
   "description": "Publish a message to a kafka topic",
   "author": "Wendell Nichols <wnichols@tibco.com>",
   "inputs":[

--- a/activity/kafkapub/ui/package.json
+++ b/activity/kafkapub/ui/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "tibco-kafkapub",
+  "version": "0.0.1",
+  "description": "Simple Kafka Publish Activity"
+}


### PR DESCRIPTION
This is a simple kafka publisher for flogo.  Supports plain, TLS, and SASL modes of operation.  Accepts a string as input and publishes a text message.  Returns the offset and partition to which the message was published.