### PR TITLE
flowaction: add support for accessing activity output via context

### DIFF
--- a/action/flow/definition/definition.go
+++ b/action/flow/definition/definition.go
@@ -103,7 +103,9 @@ type Task struct {
 
 	definition *Definition
 	parent     *Task
-	attrs      map[string]*data.Attribute
+
+	inputAttrs  map[string]*data.Attribute
+	outputAttrs map[string]*data.Attribute
 
 	inputMapper  data.Mapper
 	outputMapper data.Mapper
@@ -153,10 +155,37 @@ func (task *Task) ChildLinks() []*Link {
 }
 
 // GetAttr gets the specified attribute
+// DEPRECATED
 func (task *Task) GetAttr(attrName string) (attr *data.Attribute, exists bool) {
 
-	if task.attrs != nil {
-		attr, found := task.attrs[attrName]
+	if task.inputAttrs != nil {
+		attr, found := task.inputAttrs[attrName]
+		if found {
+			return attr, true
+		}
+	}
+
+	return nil, false
+}
+
+// GetAttr gets the specified input attribute
+func (task *Task) GetInputAttr(attrName string) (attr *data.Attribute, exists bool) {
+
+	if task.inputAttrs != nil {
+		attr, found := task.inputAttrs[attrName]
+		if found {
+			return attr, true
+		}
+	}
+
+	return nil, false
+}
+
+// GetOutputAttr gets the specified output attribute
+func (task *Task) GetOutputAttr(attrName string) (attr *data.Attribute, exists bool) {
+
+	if task.outputAttrs != nil {
+		attr, found := task.outputAttrs[attrName]
 		if found {
 			return attr, true
 		}

--- a/action/flow/definition/definition_ser.go
+++ b/action/flow/definition/definition_ser.go
@@ -3,6 +3,7 @@ package definition
 import (
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/util"
+	"github.com/TIBCOSoftware/flogo-lib/core/activity"
 )
 
 // DefinitionRep is a serializable representation of a flow Definition
@@ -24,8 +25,15 @@ type TaskRep struct {
 	ActivityRef    string             `json:"activityRef"`
 	Name           string             `json:"name"`
 	Attributes     []*data.Attribute  `json:"attributes,omitempty"`
+
+
+
+	InputAttrs     map[string]interface{}  `json:"inputs,omitempty"`
+	OutputAttrs    map[string]interface{}  `json:"outputs,omitempty"`
+
 	InputMappings  []*data.MappingDef `json:"inputMappings,omitempty"`
 	OutputMappings []*data.MappingDef `json:"ouputMappings,omitempty"`
+
 	Tasks          []*TaskRep         `json:"tasks,omitempty"`
 	Links          []*LinkRep         `json:"links,omitempty"`
 }
@@ -102,11 +110,44 @@ func addTask(def *Definition, task *Task, rep *TaskRep) {
 		task.outputMapper = GetMapperFactory().GetDefaultTaskOutputMapper(task)
 	}
 
+	// Keep for now, DEPRECATE "attributes" section from flogo.json
 	if len(rep.Attributes) > 0 {
-		task.attrs = make(map[string]*data.Attribute, len(rep.Attributes))
+		task.inputAttrs = make(map[string]*data.Attribute, len(rep.Attributes))
 
 		for _, value := range rep.Attributes {
-			task.attrs[value.Name] = value
+			task.inputAttrs[value.Name] = value
+		}
+	}
+
+	act := activity.Get(task.activityRef)
+
+	if act != nil {
+
+		if len(rep.InputAttrs) > 0 {
+			task.inputAttrs = make(map[string]*data.Attribute, len(rep.InputAttrs))
+
+			for name, value := range rep.InputAttrs {
+
+				attr := act.Metadata().Inputs[name]
+
+				if attr != nil {
+					task.inputAttrs[name] = &data.Attribute{Name: name, Type: attr.Type, Value: value}
+				}
+			}
+		}
+
+		if len(rep.OutputAttrs) > 0 {
+
+			task.outputAttrs = make(map[string]*data.Attribute, len(rep.OutputAttrs))
+
+			for name, value := range rep.OutputAttrs {
+
+				attr := act.Metadata().Outputs[name]
+
+				if attr != nil {
+					task.outputAttrs[name] = &data.Attribute{Name: name, Type: attr.Type, Value: value}
+				}
+			}
 		}
 	}
 

--- a/action/flow/instance/data.go
+++ b/action/flow/instance/data.go
@@ -147,30 +147,20 @@ type FixedTaskScope struct {
 	attrs    map[string]*data.Attribute
 	refAttrs map[string]*data.Attribute
 	task     *definition.Task
+	isInput  bool
 }
 
 // NewFixedTaskScope creates a FixedTaskScope
-func NewFixedTaskScope(refAttrs map[string]*data.Attribute, task *definition.Task) data.Scope {
+func NewFixedTaskScope(refAttrs map[string]*data.Attribute, task *definition.Task, isInput bool) data.Scope {
 
 	scope := &FixedTaskScope{
 		refAttrs: refAttrs,
 		task:     task,
+		isInput: isInput,
 	}
 
 	return scope
 }
-
-//// GetAttrType implements Scope.GetAttrType
-//func (s *FixedTaskScope) GetAttrType(attrName string) (attrType data.Type, exists bool) {
-//
-//	attr, found := s.refAttrs[attrName]
-//
-//	if found {
-//		return attr.Type, true
-//	}
-//
-//	return 0, false
-//}
 
 // GetAttr implements Scope.GetAttr
 func (s *FixedTaskScope) GetAttr(attrName string) (attr *data.Attribute, exists bool) {
@@ -186,7 +176,14 @@ func (s *FixedTaskScope) GetAttr(attrName string) (attr *data.Attribute, exists 
 
 	if s.task != nil {
 
-		attr, found := s.task.GetAttr(attrName)
+		var attr *data.Attribute
+		var found bool
+
+		if s.isInput {
+			attr, found = s.task.GetInputAttr(attrName)
+		} else {
+			attr, found = s.task.GetOutputAttr(attrName)
+		}
 
 		if !found {
 			attr, found = s.refAttrs[attrName]
@@ -228,3 +225,4 @@ func (s *FixedTaskScope) SetAttrValue(attrName string, value interface{}) error 
 
 	return nil
 }
+

--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -963,7 +963,7 @@ func (td *TaskData) OutputScope() data.Scope {
 	if len(td.task.ActivityRef()) > 0 {
 
 		act := activity.Get(td.task.ActivityRef())
-		td.outScope = NewFixedTaskScope(act.Metadata().Outputs, nil)
+		td.outScope = NewFixedTaskScope(act.Metadata().Outputs, td.task)
 
 		logger.Debugf("OutputScope: %v\n", td.outScope)
 	} else if td.task.IsScope() {
@@ -978,6 +978,17 @@ func (td *TaskData) OutputScope() data.Scope {
 func (td *TaskData) GetInput(name string) interface{} {
 
 	val, found := td.InputScope().GetAttr(name)
+	if found {
+		return val.Value
+	}
+
+	return nil
+}
+
+// GetOutput implements activity.Context.GetOutput
+func (td *TaskData) GetOutput(name string) interface{} {
+
+	val, found := td.OutputScope().GetAttr(name)
 	if found {
 		return val.Value
 	}

--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -943,7 +943,7 @@ func (td *TaskData) InputScope() data.Scope {
 	if len(td.task.ActivityRef()) > 0 {
 
 		act := activity.Get(td.task.ActivityRef())
-		td.inScope = NewFixedTaskScope(act.Metadata().Inputs, td.task)
+		td.inScope = NewFixedTaskScope(act.Metadata().Inputs, td.task, true)
 
 	} else if td.task.IsScope() {
 
@@ -963,7 +963,7 @@ func (td *TaskData) OutputScope() data.Scope {
 	if len(td.task.ActivityRef()) > 0 {
 
 		act := activity.Get(td.task.ActivityRef())
-		td.outScope = NewFixedTaskScope(act.Metadata().Outputs, td.task)
+		td.outScope = NewFixedTaskScope(act.Metadata().Outputs, td.task, false)
 
 		logger.Debugf("OutputScope: %v\n", td.outScope)
 	} else if td.task.IsScope() {


### PR DESCRIPTION
You can access output attributes via the context.  Just add them as an attribute to the activity.  Current limitation is that output/input attribute names must be unique.  We'll have to explore adding a prefix to output attributes to avoid collisions, like "output:attrname".