### PR TITLE
Remove the SyncProducer.close() api call from the activity because it causes a panic if the producer is recreated and used quickly

### DIFF
--- a/activity/kafkapub/README.md
+++ b/activity/kafkapub/README.md
@@ -16,27 +16,33 @@ Inputs and Outputs:
  "inputs":[
     {
       "name": "BrokerUrls",
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     {
       "name": "Topic",
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     {
       "name": "Message",
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     {
       "name": "user",
-      "type": "string"
+      "type": "string",
+      "required": false
     },
     {
       "name": "password",
-      "type": "string"
+      "type": "string",
+      "required": false
     },
     {
       "name": "truststore",
-      "type": "string"
+      "type": "string",
+      "required": false
     }
   ],
   "outputs": [
@@ -84,19 +90,19 @@ Configure a task to send a message to the 'syslog' topic.
         {
           "name": "BrokerUrls",
           "value": "bilbo:9092",
-          "required": false,
+          "required": true,
           "type": "string"
         },
         {
           "name": "Topic",
           "value": "syslog",
-          "required": false,
+          "required": true,
           "type": "string"
         },
         {
           "name": "Message",
           "value": "mary had a little lamb",
-          "required": false,
+          "required": true,
           "type": "string"
         }
       ]

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -45,12 +45,14 @@ func (a *KafkaPubActivity) Eval(context activity.Context) (done bool, err error)
 		flogoLogger.Errorf("Kafkapub parameters initialization got error: [%s]", err.Error())
 		return false, err
 	}
-	defer func() {
-		if err := a.syncProducer.Close(); err != nil {
-			flogoLogger.Errorf("Kafkapub producer close got error: [%s]", err.Error())
-		}
-		flogoLogger.Debugf("Kafkapub producer closed")
-	}()
+	/*
+		defer func() {
+			if err := a.syncProducer.Close(); err != nil {
+				flogoLogger.Errorf("Kafkapub producer close got error: [%s]", err.Error())
+			}
+			flogoLogger.Debugf("Kafkapub producer closed")
+		}()
+	*/
 	if message := context.GetInput("Message"); message != nil && message.(string) != "" {
 		msg := &sarama.ProducerMessage{
 			Topic: a.topic,
@@ -114,7 +116,7 @@ func initParms(a *KafkaPubActivity, context activity.Context) error {
 
 			flogoLogger.Debugf("Kafkapub initialized truststore from [%v]", trustStore)
 		} else {
-			return err
+			return false, err
 		}
 
 	}
@@ -137,7 +139,7 @@ func initParms(a *KafkaPubActivity, context activity.Context) error {
 	a.syncProducer = syncProducer
 
 	flogoLogger.Debug("Kafkapub synchronous producer created")
-	return nil
+	return false, nil
 }
 
 //Ensure that this string meets the host:port definition of a kafka hostspec

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -62,6 +62,10 @@ func (a *KafkaPubActivity) Eval(context activity.Context) (done bool, err error)
 		if err != nil {
 			return false, fmt.Errorf("kafkapub failed to send message for reason [%s]", err.Error())
 		}
+		if err := a.syncProducer.Close(); err != nil {
+			flogoLogger.Errorf("Kafkapub producer close got error: [%s]", err.Error())
+		}
+
 		context.SetOutput("partition", partition)
 		context.SetOutput("offset", offset)
 		flogoLogger.Debugf("Kafkapub message [%v] sent successfully on partition [%d] and offset [%d]",

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -116,7 +116,7 @@ func initParms(a *KafkaPubActivity, context activity.Context) error {
 
 			flogoLogger.Debugf("Kafkapub initialized truststore from [%v]", trustStore)
 		} else {
-			return false, err
+			return err
 		}
 
 	}

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -72,6 +72,10 @@ func (a *KafkaPubActivity) Eval(context activity.Context) (done bool, err error)
 }
 
 func initParms(a *KafkaPubActivity, context activity.Context) error {
+	if a.syncProducer != nil {
+		flogoLogger.Debugf("Producer parms already initialized for [%v]", a.syncProducer)
+		return nil
+	}
 	if context.GetInput("BrokerUrls") != nil && context.GetInput("BrokerUrls").(string) != "" {
 		a.kafkaConfig = sarama.NewConfig()
 		a.kafkaConfig.Producer.Return.Errors = true

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -72,10 +72,12 @@ func (a *KafkaPubActivity) Eval(context activity.Context) (done bool, err error)
 }
 
 func initParms(a *KafkaPubActivity, context activity.Context) error {
-	if a.syncProducer != nil {
-		flogoLogger.Debugf("Producer parms already initialized for [%v]", a.syncProducer)
-		return nil
-	}
+	/*
+		if a.syncProducer != nil {
+			flogoLogger.Debugf("Producer parms already initialized for [%v]", a.syncProducer)
+			return nil
+		}
+	*/
 	if context.GetInput("BrokerUrls") != nil && context.GetInput("BrokerUrls").(string) != "" {
 		a.kafkaConfig = sarama.NewConfig()
 		a.kafkaConfig.Producer.Return.Errors = true

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -72,12 +72,10 @@ func (a *KafkaPubActivity) Eval(context activity.Context) (done bool, err error)
 }
 
 func initParms(a *KafkaPubActivity, context activity.Context) error {
-	/*
-		if a.syncProducer != nil {
-			flogoLogger.Debugf("Producer parms already initialized for [%v]", a.syncProducer)
-			return nil
-		}
-	*/
+	if a.syncProducer != nil {
+		flogoLogger.Debugf("Producer parms already initialized for [%v]", a.syncProducer)
+		return nil
+	}
 	if context.GetInput("BrokerUrls") != nil && context.GetInput("BrokerUrls").(string) != "" {
 		a.kafkaConfig = sarama.NewConfig()
 		a.kafkaConfig.Producer.Return.Errors = true

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -139,7 +139,7 @@ func initParms(a *KafkaPubActivity, context activity.Context) error {
 	a.syncProducer = syncProducer
 
 	flogoLogger.Debug("Kafkapub synchronous producer created")
-	return false, nil
+	return nil
 }
 
 //Ensure that this string meets the host:port definition of a kafka hostspec

--- a/activity/kafkapub/activity.go
+++ b/activity/kafkapub/activity.go
@@ -62,10 +62,6 @@ func (a *KafkaPubActivity) Eval(context activity.Context) (done bool, err error)
 		if err != nil {
 			return false, fmt.Errorf("kafkapub failed to send message for reason [%s]", err.Error())
 		}
-		if err := a.syncProducer.Close(); err != nil {
-			flogoLogger.Errorf("Kafkapub producer close got error: [%s]", err.Error())
-		}
-
 		context.SetOutput("partition", partition)
 		context.SetOutput("offset", offset)
 		flogoLogger.Debugf("Kafkapub message [%v] sent successfully on partition [%d] and offset [%d]",

--- a/activity/kafkapub/activity.json
+++ b/activity/kafkapub/activity.json
@@ -2,7 +2,7 @@
   "name": "tibco-kafkapub",
   "version": "0.0.1",
   "type": "flogo:activity",
-  "ref": "github.com/TIBCOSoftware/flogo-contrib/activity/kafkapub",
+  "ref": "github.com/wnichols/flogo-contrib/activity/kafkapub",
   "description": "Publish a message to a kafka topic",
   "author": "Wendell Nichols <wnichols@tibco.com>",
   "inputs":[

--- a/activity/kafkapub/activity.json
+++ b/activity/kafkapub/activity.json
@@ -2,33 +2,39 @@
   "name": "tibco-kafkapub",
   "version": "0.0.1",
   "type": "flogo:activity",
-  "ref": "github.com/wnichols/flogo-contrib/activity/kafkapub",
+  "ref": "github.com/TIBCOSoftware/flogo-contrib/activity/kafkapub",
   "description": "Publish a message to a kafka topic",
   "author": "Wendell Nichols <wnichols@tibco.com>",
   "inputs":[
     {
       "name": "BrokerUrls",
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     {
       "name": "Topic",
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     {
       "name": "Message",
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     {
       "name": "user",
-      "type": "string"
+      "type": "string",
+      "required": false
     },
     {
       "name": "password",
-      "type": "string"
+      "type": "string",
+      "required": false
     },
     {
       "name": "truststore",
-      "type": "string"
+      "type": "string",
+      "required": false
     }
   ],
   "outputs": [

--- a/activity/kafkapub/activity_test.go
+++ b/activity/kafkapub/activity_test.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"testing"
 
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/test"
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
-	"github.com/TIBCOSoftware/flogo-lib/flow/test"
 )
 
 /*

--- a/activity/kafkapub/activity_test.go
+++ b/activity/kafkapub/activity_test.go
@@ -105,6 +105,41 @@ func TestSSL(t *testing.T) {
 	log.Printf("TestEval successfull.  partition [%d]  offset [%d]", tc.GetOutput("partition"), tc.GetOutput("offset"))
 }
 
+/*
+Run this test with FLOGO_LOG_LEVEL=DEBUG and observe the debug messages as the activity either creates new synpublishers, or reuses cached ones.
+*/
+func TestCache(t *testing.T) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Failed()
+			t.Errorf("panic during execution: %v", r)
+		}
+	}()
+
+	act := NewActivity(getActivityMetadata())
+	tc := test.NewTestActivityContext(getActivityMetadata())
+
+	//setup attrs
+	tc.SetInput("BrokerUrls", "cheetah:9093")
+	tc.SetInput("truststore", "/opt/kafka/kafka_2.11-0.10.2.0/keys/trust")
+	tc.SetInput("Topic", "syslog")
+	tc.SetInput("Message", "######### TLS ###########  Mary had a little lamb, its fleece was white as snow.")
+	act.Eval(tc)
+	tc.SetInput("Topic", "publishpet")
+	act.Eval(tc)
+	tc.SetInput("Topic", "publishpet")
+	act.Eval(tc)
+	tc = test.NewTestActivityContext(getActivityMetadata())
+	tc.SetInput("Message", "######### TLS ###########  Mary had a little lamb, its fleece was white as snow.")
+	tc.SetInput("BrokerUrls", "cheetah:9092")
+	tc.SetInput("Topic", "syslog")
+	act.Eval(tc)
+	tc.SetInput("Topic", "publishpet")
+	act.Eval(tc)
+	log.Printf("TestEval successfull.  partition [%d]  offset [%d]", tc.GetOutput("partition"), tc.GetOutput("offset"))
+}
+
 func TestSASL_PLAIN(t *testing.T) {
 
 	defer func() {


### PR DESCRIPTION
Because I'm not closing the producer, it gets cached by a key composed of the input args.  After some back and forth on the slack channel I felt that it was unsafe to store parms in the metadata structure while the eval method is running (multi-thread safety).  So I put them in a separate object managed on the stack and the producer cache is serialized by a mutex.

@torresashjian 

p.s.  because I was testing I was using the master branch for convenience, so this pull comes from my master. :(