### PR TITLE
Change task Id from int to string

### DIFF
--- a/action/flow/action.go
+++ b/action/flow/action.go
@@ -12,17 +12,17 @@ import (
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/extension"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/instance"
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/model"
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/provider"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/tester"
 	"github.com/TIBCOSoftware/flogo-lib/core/action"
 	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/model"
-	"github.com/TIBCOSoftware/flogo-lib/util"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/provider"
+	"github.com/TIBCOSoftware/flogo-lib/util"
 )
 
 const (
-	FLOW_REF  = "github.com/TIBCOSoftware/flogo-contrib/action/flow"
+	FLOW_REF = "github.com/TIBCOSoftware/flogo-contrib/action/flow"
 )
 
 // ActionOptions are the options for the FlowAction
@@ -32,8 +32,8 @@ type ActionOptions struct {
 }
 
 type FlowAction struct {
-	idGenerator            *util.Generator
-	actionOptions          *ActionOptions
+	idGenerator   *util.Generator
+	actionOptions *ActionOptions
 }
 
 // Provides the different extension points to the Flow Action
@@ -46,10 +46,9 @@ type ExtensionProvider interface {
 	GetFlowTester() *tester.RestEngineTester
 }
 
-var actionMu  sync.Mutex
+var actionMu sync.Mutex
 var ep ExtensionProvider
 var flowAction *FlowAction
-
 
 func init() {
 	action.RegisterFactory(FLOW_REF, &FlowFactory{})
@@ -272,4 +271,3 @@ func (rh *SimpleReplyHandler) Reply(replyCode int, replyData interface{}, err er
 
 	rh.resultHandler.HandleResult(replyCode, replyData, err)
 }
-

--- a/action/flow/action_test.go
+++ b/action/flow/action_test.go
@@ -24,9 +24,6 @@ func TestInitNoFlavorError(t *testing.T) {
 	flowAction := f.New(mockConfig)
 	assert.NotNil(t, flowAction)
 
-
-
-
 	// If reaches here it should fail, as it should panic before
 	t.Fail()
 }
@@ -73,7 +70,6 @@ func TestInitCompressedFlowFlavorError(t *testing.T) {
 	f := &FlowFactory{}
 	flowAction := f.New(mockConfig)
 	assert.NotNil(t, flowAction)
-
 
 	// If reaches here it should fail, as it should panic before
 	t.Fail()

--- a/action/flow/definition/definition.go
+++ b/action/flow/definition/definition.go
@@ -20,7 +20,7 @@ type Definition struct {
 
 	inputMapper data.Mapper
 	links       map[int]*Link
-	tasks       map[int]*Task
+	tasks       map[string]*Task
 
 	linkExprMgr LinkExprManager
 }
@@ -63,7 +63,7 @@ func (pd *Definition) GetAttr(attrName string) (attr *data.Attribute, exists boo
 }
 
 // GetTask returns the task with the specified ID
-func (pd *Definition) GetTask(taskID int) *Task {
+func (pd *Definition) GetTask(taskID string) *Task {
 	task := pd.tasks[taskID]
 	return task
 }
@@ -92,7 +92,7 @@ func (pd *Definition) GetLinkExprManager() LinkExprManager {
 // a task.  It contains its data (attributes) and its
 // nested structure (child tasks & child links).
 type Task struct {
-	id           int
+	id           string
 	typeID       int
 	activityType string
 	activityRef  string
@@ -115,7 +115,7 @@ type Task struct {
 }
 
 // ID gets the id of the task
-func (task *Task) ID() int {
+func (task *Task) ID() string {
 	return task.id
 }
 

--- a/action/flow/definition/definition_ser_test.go
+++ b/action/flow/definition/definition_ser_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const defJSON = `
@@ -79,4 +81,33 @@ func TestRestartWithFlowData(t *testing.T) {
 	def, _ := NewDefinition(defRep)
 
 	fmt.Printf("Definition: %v", def)
+}
+
+type MyDummyJson struct {
+	Value interface{}
+}
+
+func TestConvertInterfaceToString(t *testing.T) {
+	intJson := `{"Value": 1}`
+	dummyJ := &MyDummyJson{}
+
+	err := json.Unmarshal([]byte(intJson), &dummyJ)
+
+	assert.Nil(t, err)
+
+	result := convertInterfaceToString(dummyJ.Value)
+
+	assert.Equal(t, "1", result)
+
+	strJson := `{"Value": "stringId"}`
+	dummyJ = &MyDummyJson{}
+
+	err = json.Unmarshal([]byte(strJson), &dummyJ)
+
+	assert.Nil(t, err)
+
+	result = convertInterfaceToString(dummyJ.Value)
+
+	assert.Equal(t, "stringId", result)
+
 }

--- a/action/flow/definition/expr.go
+++ b/action/flow/definition/expr.go
@@ -10,12 +10,12 @@ type LinkExprManager interface {
 }
 
 func NewLinkExprError(msg string) *LinkExprError {
-	return &LinkExprError{msg:msg}
+	return &LinkExprError{msg: msg}
 }
 
 // LinkExprError thrown if error is encountered evaluating an link expression
 type LinkExprError struct {
-	 msg string
+	msg string
 }
 
 func (e *LinkExprError) Error() string {
@@ -23,11 +23,10 @@ func (e *LinkExprError) Error() string {
 }
 
 type LinkExprManagerFactory interface {
-
 	NewLinkExprManager(def *Definition) LinkExprManager
 }
 
-var	linkExprMangerFactory LinkExprManagerFactory
+var linkExprMangerFactory LinkExprManagerFactory
 
 func SetLinkExprManagerFactory(factory LinkExprManagerFactory) {
 	linkExprMangerFactory = factory
@@ -44,7 +43,7 @@ func GetExpressionLinks(def *Definition) []*Link {
 
 	getExpressionLinks(def.RootTask(), &links)
 
-	if (def.ErrorHandlerTask() != nil) {
+	if def.ErrorHandlerTask() != nil {
 		getExpressionLinks(def.ErrorHandlerTask(), &links)
 	}
 

--- a/action/flow/definition/mapper.go
+++ b/action/flow/definition/mapper.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
 )
-
 
 // MapperDef represents a Mapper, which is a collection of mappings
 type MapperDef struct {
@@ -33,7 +32,7 @@ type MapperFactory interface {
 	GetDefaultTaskOutputMapper(task *Task) data.Mapper
 }
 
-var	mapperFactory MapperFactory
+var mapperFactory MapperFactory
 
 func SetMapperFactory(mapper MapperFactory) {
 	mapperFactory = mapper
@@ -49,27 +48,25 @@ func GetMapperFactory() MapperFactory {
 	return mapperFactory
 }
 
-
 //todo move the following to flowAction
 
 type BasicMapperFactory struct {
-
 }
 
-func(mf *BasicMapperFactory) NewMapper(mapperDef *MapperDef) data.Mapper {
+func (mf *BasicMapperFactory) NewMapper(mapperDef *MapperDef) data.Mapper {
 	return NewBasicMapper(mapperDef)
 }
 
-func(mf *BasicMapperFactory) NewTaskInputMapper(task *Task, mapperDef *MapperDef) data.Mapper {
+func (mf *BasicMapperFactory) NewTaskInputMapper(task *Task, mapperDef *MapperDef) data.Mapper {
 	return NewBasicMapper(mapperDef)
 }
 
-func(mf *BasicMapperFactory) NewTaskOutputMapper(task *Task, mapperDef *MapperDef) data.Mapper {
+func (mf *BasicMapperFactory) NewTaskOutputMapper(task *Task, mapperDef *MapperDef) data.Mapper {
 	return NewBasicMapper(mapperDef)
 }
 
 func (mf *BasicMapperFactory) GetDefaultTaskOutputMapper(task *Task) data.Mapper {
-	return &DefaultOutputMapper{task:task}
+	return &DefaultOutputMapper{task: task}
 }
 
 // BasicMapper is a simple object holding and executing mappings
@@ -189,7 +186,7 @@ func (m *BasicMapper) Apply(inputScope data.Scope, outputScope data.Scope) error
 		case data.MtLiteral:
 			outputScope.SetAttrValue(mapping.MapTo, mapping.Value)
 		case data.MtExpression:
-		//todo implement script mapping
+			//todo implement script mapping
 		}
 	}
 
@@ -207,7 +204,7 @@ func (m *DefaultOutputMapper) Apply(inputScope data.Scope, outputScope data.Scop
 
 	act := activity.Get(m.task.ActivityRef())
 
-	attrNS := "{A" + strconv.Itoa(m.task.ID()) + "."
+	attrNS := "{A" + m.task.ID() + "."
 
 	for _, attr := range act.Metadata().Outputs {
 

--- a/action/flow/extension/extension.go
+++ b/action/flow/extension/extension.go
@@ -3,10 +3,10 @@ package extension
 import (
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/instance"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/tester"
-	"github.com/TIBCOSoftware/flogo-contrib/model/simple"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/model"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/provider"
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/tester"
+	"github.com/TIBCOSoftware/flogo-contrib/model/simple"
 )
 
 //Provider is the extension provider for the flow action

--- a/action/flow/instance/data.go
+++ b/action/flow/instance/data.go
@@ -1,12 +1,10 @@
 package instance
 
 import (
-	"strconv"
-
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
 )
 
 func applyInputMapper(pi *Instance, taskData *TaskData) error {
@@ -110,7 +108,7 @@ func applyDefaultActivityOutputMappings(pi *Instance, taskData *TaskData) {
 
 	activity := activity.Get(taskData.task.ActivityRef())
 
-	attrNS := "{A" + strconv.Itoa(taskData.task.ID()) + "."
+	attrNS := "{A" + taskData.task.ID() + "."
 
 	for _, attr := range activity.Metadata().Outputs {
 
@@ -156,7 +154,7 @@ func NewFixedTaskScope(refAttrs map[string]*data.Attribute, task *definition.Tas
 	scope := &FixedTaskScope{
 		refAttrs: refAttrs,
 		task:     task,
-		isInput: isInput,
+		isInput:  isInput,
 	}
 
 	return scope
@@ -225,4 +223,3 @@ func (s *FixedTaskScope) SetAttrValue(attrName string, value interface{}) error 
 
 	return nil
 }
-

--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -3,17 +3,16 @@ package instance
 import (
 	"fmt"
 	"runtime/debug"
-	"strconv"
 	"sync"
 
-	"github.com/TIBCOSoftware/flogo-lib/core/activity"
-	"github.com/TIBCOSoftware/flogo-lib/core/data"
-	"github.com/TIBCOSoftware/flogo-lib/logger"
-	"github.com/TIBCOSoftware/flogo-lib/util"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/model"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/provider"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/support"
+	"github.com/TIBCOSoftware/flogo-lib/core/activity"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+	"github.com/TIBCOSoftware/flogo-lib/util"
 )
 
 const (
@@ -63,7 +62,7 @@ func New(instanceID string, flowURI string, flow *definition.Definition, flowMod
 	taskEnv.Task = flow.RootTask()
 	taskEnv.taskID = flow.RootTask().ID()
 	taskEnv.Instance = &inst
-	taskEnv.TaskDatas = make(map[int]*TaskData)
+	taskEnv.TaskDatas = make(map[string]*TaskData)
 	taskEnv.LinkDatas = make(map[int]*LinkData)
 
 	inst.RootTaskEnv = &taskEnv
@@ -413,7 +412,7 @@ func (pi *Instance) handleTaskDone(taskBehavior model.TaskBehavior, taskData *Ta
 
 func (pi *Instance) appendErrorData(err error) {
 
-	switch  err.(type) {
+	switch err.(type) {
 	case *definition.LinkExprError:
 		pi.AddAttr("{Error.type}", data.STRING, "link_expr")
 		pi.AddAttr("{Error.message}", data.STRING, err.Error())
@@ -488,7 +487,7 @@ func (pi *Instance) HandleGlobalError() {
 			taskEnv.Task = ehTask
 			taskEnv.taskID = ehTask.ID()
 			taskEnv.Instance = pi
-			taskEnv.TaskDatas = make(map[int]*TaskData)
+			taskEnv.TaskDatas = make(map[string]*TaskData)
 			taskEnv.LinkDatas = make(map[int]*LinkData)
 
 			pi.EhTaskEnv = &taskEnv
@@ -578,10 +577,10 @@ type TaskEnv struct {
 	Instance  *Instance
 	ParentEnv *TaskEnv
 
-	TaskDatas map[int]*TaskData
+	TaskDatas map[string]*TaskData
 	LinkDatas map[int]*LinkData
 
-	taskID int // for deserialization
+	taskID string // for deserialization
 }
 
 // init initializes the Task Environment, typically called on deserialization
@@ -687,7 +686,7 @@ type TaskData struct {
 
 	changes int
 
-	taskID int //needed for serialization
+	taskID string //needed for serialization
 }
 
 // NewTaskData creates a TaskData for the specified task in the specified task
@@ -919,7 +918,7 @@ func (td *TaskData) EvalActivity() (done bool, evalErr error) {
 // Failed marks the Activity as failed
 func (td *TaskData) Failed(err error) {
 
-	errorMsgAttr := "[A" + strconv.Itoa(td.task.ID()) + "._errorMsg]"
+	errorMsgAttr := "[A" + td.task.ID() + "._errorMsg]"
 	td.taskEnv.Instance.AddAttr(errorMsgAttr, data.STRING, err.Error())
 }
 
@@ -1059,7 +1058,7 @@ type WorkItem struct {
 	ExecType ExecType  `json:"execType"`
 	EvalCode int       `json:"code"`
 
-	TaskID int `json:"taskID"` //for now need for ser
+	TaskID string `json:"taskID"` //for now need for ser
 	//taskCtxID int `json:"taskCtxID"` //not needed for now
 }
 

--- a/action/flow/instance/instance_chg.go
+++ b/action/flow/instance/instance_chg.go
@@ -26,7 +26,7 @@ type WorkItemQueueChange struct {
 // TaskDataChange represents a change to a TaskData
 type TaskDataChange struct {
 	ChgType  ChgType
-	ID       int
+	ID       string
 	TaskData *TaskData
 }
 
@@ -55,7 +55,7 @@ type AttributeChange struct {
 type InstanceChangeTracker struct {
 	wiqChanges map[int]*WorkItemQueueChange
 
-	tdChanges map[int]*TaskDataChange
+	tdChanges map[string]*TaskDataChange
 	ldChanges map[int]*LinkDataChange
 
 	instChange *InstanceChange
@@ -117,7 +117,7 @@ func (ict *InstanceChangeTracker) trackWorkItem(wiChange *WorkItemQueueChange) {
 func (ict *InstanceChangeTracker) trackTaskData(tdChange *TaskDataChange) {
 
 	if ict.tdChanges == nil {
-		ict.tdChanges = make(map[int]*TaskDataChange)
+		ict.tdChanges = make(map[string]*TaskDataChange)
 	}
 
 	ict.tdChanges[tdChange.ID] = tdChange

--- a/action/flow/instance/instance_ser.go
+++ b/action/flow/instance/instance_ser.go
@@ -107,7 +107,7 @@ func (te *TaskEnv) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(&struct {
 		ID        int         `json:"id"`
-		TaskID    int         `json:"taskId"`
+		TaskID    string      `json:"taskId"`
 		TaskDatas []*TaskData `json:"taskDatas"`
 		LinkDatas []*LinkData `json:"linkDatas"`
 	}{
@@ -123,7 +123,7 @@ func (te *TaskEnv) UnmarshalJSON(data []byte) error {
 
 	ser := &struct {
 		ID        int         `json:"id"`
-		TaskID    int         `json:"taskId"`
+		TaskID    string      `json:"taskId"`
 		TaskDatas []*TaskData `json:"taskDatas"`
 		LinkDatas []*LinkData `json:"linkDatas"`
 	}{}
@@ -134,7 +134,7 @@ func (te *TaskEnv) UnmarshalJSON(data []byte) error {
 
 	te.ID = ser.ID
 	te.taskID = ser.TaskID
-	te.TaskDatas = make(map[int]*TaskData)
+	te.TaskDatas = make(map[string]*TaskData)
 	te.LinkDatas = make(map[int]*LinkData)
 
 	for _, value := range ser.TaskDatas {
@@ -158,7 +158,7 @@ func (td *TaskData) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&struct {
-		TaskID int               `json:"taskId"`
+		TaskID string            `json:"taskId"`
 		State  int               `json:"state"`
 		Attrs  []*data.Attribute `json:"attrs"`
 	}{
@@ -171,7 +171,7 @@ func (td *TaskData) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON overrides the default UnmarshalJSON for TaskData
 func (td *TaskData) UnmarshalJSON(d []byte) error {
 	ser := &struct {
-		TaskID int               `json:"taskId"`
+		TaskID string            `json:"taskId"`
 		State  int               `json:"state"`
 		Attrs  []*data.Attribute `json:"attrs"`
 	}{}

--- a/action/flow/instance/recorder.go
+++ b/action/flow/instance/recorder.go
@@ -1,14 +1,14 @@
 package instance
 
 import (
-	"strings"
+	"bytes"
 	"encoding/json"
 	"net/http"
-	"bytes"
+	"strings"
 
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/service"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"github.com/TIBCOSoftware/flogo-lib/util"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/service"
 )
 
 // StateRecorder is the interface that describes a service that can record

--- a/action/flow/model/model.go
+++ b/action/flow/model/model.go
@@ -1,6 +1,5 @@
 package model
 
-
 // FlowModel defines the execution Model for a Flow.  It contains the
 // execution behaviors for Flows and Tasks.
 type FlowModel struct {

--- a/action/flow/provider/provider.go
+++ b/action/flow/provider/provider.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/support"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/script/fggos"
-	"github.com/TIBCOSoftware/flogo-lib/util"
-	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/script/fggos"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/service"
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/support"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+	"github.com/TIBCOSoftware/flogo-lib/util"
 )
-
 
 // Provider is the interface that describes an object
 // that can provide flow definitions from a URI

--- a/action/flow/script/fggos/linkexpr.go
+++ b/action/flow/script/fggos/linkexpr.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/TIBCOSoftware/flogo-lib/core/data"
-	"github.com/japm/goScript"
-	"github.com/TIBCOSoftware/flogo-lib/logger"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
 	"fmt"
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+	"github.com/japm/goScript"
 )
 
 // GosLinkExprManager is the Lua Implementation of a Link Expression Manager
@@ -92,12 +92,12 @@ func transExpr(s string) ([]*varInfo, string) {
 
 			if isdefcheck {
 				isd++
-				vars = append(vars, &varInfo{isd: isd, name: s[i+1: j]})
+				vars = append(vars, &varInfo{isd: isd, name: s[i+1 : j]})
 				rvars = append(rvars, s[i-10:j+1])
 				rvars = append(rvars, "isd"+strconv.Itoa(isd))
 				i = j + 1
 			} else {
-				vars = append(vars, &varInfo{name: s[i+1: j]})
+				vars = append(vars, &varInfo{name: s[i+1 : j]})
 				rvars = append(rvars, s[i:j])
 				rvars = append(rvars, `v["`+s[i+1:j]+`"]`)
 				i = j

--- a/action/flow/script/fggos/linkexpr_test.go
+++ b/action/flow/script/fggos/linkexpr_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
 )
 
 const defJSON = `

--- a/action/flow/script/fgn/linkexpr.go
+++ b/action/flow/script/fgn/linkexpr.go
@@ -1,8 +1,8 @@
 package fgn
 
 import (
-	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
 )
 
 type ExprFunc func(map[string]interface{}) bool

--- a/action/flow/service/services.go
+++ b/action/flow/service/services.go
@@ -1,6 +1,5 @@
 package service
 
-
 const (
 	// ServiceStateRecorder is the name of the StateRecorder service used in configuration
 	ServiceStateRecorder string = "stateRecorder"

--- a/action/flow/support/interceptor.go
+++ b/action/flow/support/interceptor.go
@@ -9,7 +9,7 @@ import "github.com/TIBCOSoftware/flogo-lib/core/data"
 type Interceptor struct {
 	TaskInterceptors []*TaskInterceptor `json:"tasks"`
 
-	taskInterceptorMap map[int]*TaskInterceptor
+	taskInterceptorMap map[string]*TaskInterceptor
 }
 
 // Init initializes the FlowInterceptor, usually called after deserialization
@@ -18,7 +18,7 @@ func (pi *Interceptor) Init() {
 	numAttrs := len(pi.TaskInterceptors)
 	if numAttrs > 0 {
 
-		pi.taskInterceptorMap = make(map[int]*TaskInterceptor, numAttrs)
+		pi.taskInterceptorMap = make(map[string]*TaskInterceptor, numAttrs)
 
 		for _, interceptor := range pi.TaskInterceptors {
 			pi.taskInterceptorMap[interceptor.ID] = interceptor
@@ -27,7 +27,7 @@ func (pi *Interceptor) Init() {
 }
 
 // GetTaskInterceptor get the TaskInterceptor for the specified task (referred to by ID)
-func (pi *Interceptor) GetTaskInterceptor(taskID int) *TaskInterceptor {
+func (pi *Interceptor) GetTaskInterceptor(taskID string) *TaskInterceptor {
 	return pi.taskInterceptorMap[taskID]
 }
 
@@ -35,7 +35,7 @@ func (pi *Interceptor) GetTaskInterceptor(taskID int) *TaskInterceptor {
 // Also, a 'Skip' flag can be enabled to inform the runtime that the task should not
 // execute.
 type TaskInterceptor struct {
-	ID      int               `json:"id"`
+	ID      string            `json:"id"`
 	Skip    bool              `json:"skip,omitempty"`
 	Inputs  []*data.Attribute `json:"inputs,omitempty"`
 	Outputs []*data.Attribute `json:"outputs,omitempty"`

--- a/action/flow/support/manager.go
+++ b/action/flow/support/manager.go
@@ -11,16 +11,15 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/TIBCOSoftware/flogo-lib/util"
-	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+	"github.com/TIBCOSoftware/flogo-lib/util"
 )
 
 const (
 	uriSchemeFile = "file://"
 	uriSchemeHttp = "http://"
 )
-
 
 // FlowManager is a simple manager for flows
 type FlowManager struct {

--- a/action/flow/support/patch.go
+++ b/action/flow/support/patch.go
@@ -7,7 +7,7 @@ import "github.com/TIBCOSoftware/flogo-lib/core/data"
 type Patch struct {
 	TaskPatches []*TaskPatch `json:"tasks"` //put in mapper object
 
-	taskPatchMap map[int]*TaskPatch
+	taskPatchMap map[string]*TaskPatch
 }
 
 // Init initializes the FlowPatch, usually called after deserialization
@@ -16,7 +16,7 @@ func (pp *Patch) Init() {
 	numAttrs := len(pp.TaskPatches)
 	if numAttrs > 0 {
 
-		pp.taskPatchMap = make(map[int]*TaskPatch, numAttrs)
+		pp.taskPatchMap = make(map[string]*TaskPatch, numAttrs)
 
 		for _, patch := range pp.TaskPatches {
 			pp.taskPatchMap[patch.ID] = patch
@@ -25,12 +25,12 @@ func (pp *Patch) Init() {
 }
 
 // GetPatch returns the Task Patch for the specified task (referred to by ID)
-func (pp *Patch) GetPatch(taskID int) *TaskPatch {
+func (pp *Patch) GetPatch(taskID string) *TaskPatch {
 	return pp.taskPatchMap[taskID]
 }
 
 // GetInputMapper returns the InputMapper for the specified task (referred to by ID)
-func (pp *Patch) GetInputMapper(taskID int) data.Mapper {
+func (pp *Patch) GetInputMapper(taskID string) data.Mapper {
 	taskPatch, exists := pp.taskPatchMap[taskID]
 
 	if exists {
@@ -41,7 +41,7 @@ func (pp *Patch) GetInputMapper(taskID int) data.Mapper {
 }
 
 // GetOutputMapper returns the OutputMapper for the specified task (referred to by ID)
-func (pp *Patch) GetOutputMapper(taskID int) data.Mapper {
+func (pp *Patch) GetOutputMapper(taskID string) data.Mapper {
 	taskPatch, exists := pp.taskPatchMap[taskID]
 
 	if exists {
@@ -55,7 +55,7 @@ func (pp *Patch) GetOutputMapper(taskID int) data.Mapper {
 // input mappings, output mappings.  This is used to override the corresponding
 // settings for a Task in the Process
 type TaskPatch struct {
-	ID             int                `json:"id"`
+	ID             string             `json:"id"`
 	Attributes     []*data.Attribute  `json:"attributes"`
 	InputMappings  []*data.MappingDef `json:"inputMappings"` //put in mapper object
 	OutputMappings []*data.MappingDef `json:"ouputMappings"` //put in mapper object

--- a/action/flow/test/context.go
+++ b/action/flow/test/context.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
 )
 
 // TestActivityContext is a dummy ActivityContext to assist in testing
@@ -11,9 +11,9 @@ type TestActivityContext struct {
 	TaskNameVal string
 	Attrs       map[string]*data.Attribute
 
-	metadata    *activity.Metadata
-	inputs      map[string]*data.Attribute
-	outputs     map[string]*data.Attribute
+	metadata *activity.Metadata
+	inputs   map[string]*data.Attribute
+	outputs  map[string]*data.Attribute
 }
 
 // TestFlowDetails simple FlowDetails for use in testing

--- a/action/flow/tester/extension.go
+++ b/action/flow/tester/extension.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/instance"
-	"github.com/TIBCOSoftware/flogo-contrib/model/simple"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/model"
-	"github.com/TIBCOSoftware/flogo-lib/util"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/provider"
+	"github.com/TIBCOSoftware/flogo-contrib/model/simple"
+	"github.com/TIBCOSoftware/flogo-lib/util"
 )
 
 const (

--- a/action/flow/tester/request.go
+++ b/action/flow/tester/request.go
@@ -3,19 +3,18 @@ package tester
 import (
 	"context"
 
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/instance"
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/support"
 	"github.com/TIBCOSoftware/flogo-lib/core/action"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
 	"github.com/TIBCOSoftware/flogo-lib/engine/runner"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/support"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/instance"
 )
 
 const (
-	FLOW_REF  = "github.com/TIBCOSoftware/flogo-contrib/action/flow"
+	FLOW_REF = "github.com/TIBCOSoftware/flogo-contrib/action/flow"
 )
-
 
 // RequestProcessor processes request objects and invokes the corresponding
 // flow Manager methods
@@ -55,7 +54,7 @@ func (rp *RequestProcessor) StartFlow(startRequest *StartRequest) (code int, ret
 	}
 
 	factory := action.GetFactory(FLOW_REF)
-	act := factory.New(&action.Config{Id:"flow"})
+	act := factory.New(&action.Config{Id: "flow"})
 
 	ctx := trigger.NewContext(context.Background(), attrs)
 
@@ -84,7 +83,7 @@ func (rp *RequestProcessor) RestartFlow(restartRequest *RestartRequest) (code in
 	}
 
 	factory := action.GetFactory(FLOW_REF)
-	act := factory.New(&action.Config{Id:"flow"})
+	act := factory.New(&action.Config{Id: "flow"})
 
 	ro := &instance.RunOptions{Op: instance.OpRestart, ReturnID: true, InitialState: restartRequest.InitialState, ExecOptions: execOptions}
 	return rp.runner.Run(ctx, act, restartRequest.InitialState.FlowURI, ro)
@@ -111,7 +110,7 @@ func (rp *RequestProcessor) ResumeFlow(resumeRequest *ResumeRequest) (code int, 
 	}
 
 	factory := action.GetFactory(FLOW_REF)
-	act := factory.New(&action.Config{Id:"flow"})
+	act := factory.New(&action.Config{Id: "flow"})
 
 	ro := &instance.RunOptions{Op: instance.OpResume, ReturnID: true, InitialState: resumeRequest.State, ExecOptions: execOptions}
 	return rp.runner.Run(ctx, act, resumeRequest.State.FlowURI, ro)

--- a/action/flow/tester/service.go
+++ b/action/flow/tester/service.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/instance"
+	"github.com/TIBCOSoftware/flogo-contrib/action/flow/service"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"github.com/TIBCOSoftware/flogo-lib/util"
-	"github.com/TIBCOSoftware/flogo-contrib/action/flow/service"
+	"github.com/julienschmidt/httprouter"
 )
 
 // RestEngineTester is default REST implementation of the EngineTester


### PR DESCRIPTION
Made the needed changes to support task Id to be of string type.

The changes are backward compatible, so old int task Ids will also work.