### PR TITLE
Support new resolver syntax

### DIFF
--- a/action/flow/definition/mapper.go
+++ b/action/flow/definition/mapper.go
@@ -114,7 +114,8 @@ func (m *BasicMapper) Apply(inputScope data.Scope, outputScope data.Scope) error
 			// This is the Backward compatible case
 			case data.RES_DEFAULT:
 				attrName, attrPath, pathType := data.GetAttrPath(mapping.Value)
-				tv, exists := inputScope.GetAttr(attrName)
+				var tv *data.Attribute
+				tv, exists = inputScope.GetAttr(attrName)
 				if tv == nil {
 					err := fmt.Errorf("Failed to resolve attribute '%s' for mapping value '%s'", attrName, mapping.Value)
 					logger.Error(err.Error())
@@ -171,7 +172,6 @@ func (m *BasicMapper) Apply(inputScope data.Scope, outputScope data.Scope) error
 
 			//todo implement type conversion
 			if exists {
-
 				attrName, attrPath, pathType := data.GetAttrPath(mapping.MapTo)
 				toAttr, oe := outputScope.GetAttr(attrName)
 
@@ -252,7 +252,7 @@ func (m *DefaultOutputMapper) Apply(inputScope data.Scope, outputScope data.Scop
 
 	attrNS := "{A" + m.task.ID() + "."
 
-	attrNS2 := "${activity." + m.task.ID() + "."
+	attrNS2 := "{activity." + m.task.ID() + "."
 
 	for _, attr := range act.Metadata().Outputs {
 

--- a/action/flow/definition/mapper.go
+++ b/action/flow/definition/mapper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/property"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
+	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
 )
 
 // MapperDef represents a Mapper, which is a collection of mappings
@@ -162,12 +163,13 @@ func (m *BasicMapper) Apply(inputScope data.Scope, outputScope data.Scope) error
 					return err
 				}
 			case data.RES_TRIGGER:
-				// TODO finish trigger implementation
 				// Trigger resolution
-				//attrValue, exists = trigger.Resolve(inputScope, mapping.Value)
-				//if !exists {
-				//		return fmt.Errorf("Could not resolve expression '%s' for the current input scope", mapping.Value)
-				//}
+				attrValue, exists = trigger.Resolve(inputScope, mapping.Value)
+				if !exists {
+					err := fmt.Errorf("Could not resolve expression '%s' for the current input scope", mapping.Value)
+					logger.Error(err.Error())
+					return err
+				}
 			}
 
 			//todo implement type conversion
@@ -252,7 +254,7 @@ func (m *DefaultOutputMapper) Apply(inputScope data.Scope, outputScope data.Scop
 
 	attrNS := "{A" + m.task.ID() + "."
 
-	attrNS2 := "{activity." + m.task.ID() + "."
+	attrNS2 := "${activity." + m.task.ID() + "."
 
 	for _, attr := range act.Metadata().Outputs {
 

--- a/action/flow/instance/data.go
+++ b/action/flow/instance/data.go
@@ -109,6 +109,7 @@ func applyDefaultActivityOutputMappings(pi *Instance, taskData *TaskData) {
 	activity := activity.Get(taskData.task.ActivityRef())
 
 	attrNS := "{A" + taskData.task.ID() + "."
+	attrNS2 := "${activity." + taskData.task.ID() + "."
 
 	for _, attr := range activity.Metadata().Outputs {
 
@@ -116,6 +117,7 @@ func applyDefaultActivityOutputMappings(pi *Instance, taskData *TaskData) {
 
 		if oAttr != nil {
 			pi.AddAttr(attrNS+attr.Name+"}", attr.Type, oAttr.Value)
+			pi.AddAttr(attrNS2+attr.Name+"}", attr.Type, oAttr.Value)
 		}
 	}
 }
@@ -136,7 +138,9 @@ func applyDefaultInstanceInputMappings(pi *Instance, attrs []*data.Attribute) {
 	for _, attr := range attrs {
 
 		attrName := "{TriggerData." + attr.Name + "}"
+		attrName2 := "${trigger." + attr.Name + "}"
 		pi.AddAttr(attrName, attr.Type, attr.Value)
+		pi.AddAttr(attrName2, attr.Type, attr.Value)
 	}
 }
 

--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -921,6 +921,8 @@ func (td *TaskData) Failed(err error) {
 
 	errorMsgAttr := "[A" + td.task.ID() + "._errorMsg]"
 	td.taskEnv.Instance.AddAttr(errorMsgAttr, data.STRING, err.Error())
+	errorMsgAttr2 := "[activity." + td.task.ID() + "._errorMsg]"
+	td.taskEnv.Instance.AddAttr(errorMsgAttr2, data.STRING, err.Error())
 }
 
 // FlowDetails implements activity.Context.FlowName method

--- a/action/flow/script/fggos/linkexpr.go
+++ b/action/flow/script/fggos/linkexpr.go
@@ -145,6 +145,7 @@ func (em *GosLinkExprManager) EvalLinkExpr(link *definition.Link, scope data.Sco
 	vars, attrsOK := em.values[link.ID()]
 	expr, exprOK := em.exprs[link.ID()]
 
+
 	if !attrsOK || !exprOK {
 
 		return false, fmt.Errorf("Unable to evaluate expression '%s', did not compile properly\n", link.Value())
@@ -161,6 +162,7 @@ func (em *GosLinkExprManager) EvalLinkExpr(link *definition.Link, scope data.Sco
 		attr, exists := scope.GetAttr(attrName)
 
 		attrValue = attr.Value
+		logger.Debugf("LINK EXPRESSION varInfo.name: '%s', attrName: '%s', attrPath: '%s', attr: '%+v', attrValue: '%s' ", varInfo.name, attrName, attrPath, attr, attrValue)
 
 		if varInfo.isd > 0 {
 

--- a/action/flow/script/fggos/linkexpr.go
+++ b/action/flow/script/fggos/linkexpr.go
@@ -97,9 +97,12 @@ func transExpr(s string) ([]*varInfo, string) {
 				rvars = append(rvars, "isd"+strconv.Itoa(isd))
 				i = j + 1
 			} else {
-				vars = append(vars, &varInfo{name: s[i+1 : j]})
+				name := s[i+1 : j]
+				// Workaround until we don't support old resolutions
+				name = strings.Replace(strings.Replace(name, "{trigger.", "${trigger.", -1), "{activity.", "${activity.", -1)
+				vars = append(vars, &varInfo{name: name})
 				rvars = append(rvars, s[i:j])
-				rvars = append(rvars, `v["`+s[i+1:j]+`"]`)
+				rvars = append(rvars, `v["`+name+`"]`)
 				i = j
 			}
 		}
@@ -145,7 +148,6 @@ func (em *GosLinkExprManager) EvalLinkExpr(link *definition.Link, scope data.Sco
 	vars, attrsOK := em.values[link.ID()]
 	expr, exprOK := em.exprs[link.ID()]
 
-
 	if !attrsOK || !exprOK {
 
 		return false, fmt.Errorf("Unable to evaluate expression '%s', did not compile properly\n", link.Value())
@@ -162,8 +164,6 @@ func (em *GosLinkExprManager) EvalLinkExpr(link *definition.Link, scope data.Sco
 		attr, exists := scope.GetAttr(attrName)
 
 		attrValue = attr.Value
-		logger.Debugf("LINK EXPRESSION varInfo.name: '%s', attrName: '%s', attrPath: '%s', attr: '%+v', attrValue: '%s' ", varInfo.name, attrName, attrPath, attr, attrValue)
-
 		if varInfo.isd > 0 {
 
 			if exists && len(attrPath) > 0 {


### PR DESCRIPTION
Support new syntax on input mapper and branch conditions:

New format explained here: http://confluence.tibco.com/display/FLOGO/Architecture#Architecture-ExpressionSyntaxProposal

This solution is backward compatible with old format.