### PR TITLE
CLI Trigger

### DIFF
--- a/action/flow/definition/mapper.go
+++ b/action/flow/definition/mapper.go
@@ -131,8 +131,11 @@ func (m *BasicMapper) Apply(inputScope data.Scope, outputScope data.Scope) error
 						//assigning part of array
 						idx, _ := strconv.Atoi(attrPath)
 						//todo handle err
-						valArray := attrValue.([]interface{})
-						attrValue = valArray[idx]
+						if valArray, ok := attrValue.([]interface{}); ok {
+							attrValue = valArray[idx]
+						} else if valArray, ok := attrValue.([]string); ok {
+							attrValue = valArray[idx]
+						}
 					} else {
 						//for now assume if we have a path, attr is "object"
 						valMap := attrValue.(map[string]interface{})

--- a/action/flow/definition/mapper.go
+++ b/action/flow/definition/mapper.go
@@ -1,24 +1,17 @@
 package definition
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/TIBCOSoftware/flogo-lib/core/activity"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
-	"github.com/TIBCOSoftware/flogo-lib/core/property"
-	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
-	"github.com/TIBCOSoftware/flogo-lib/logger"
+	"github.com/TIBCOSoftware/flogo-lib/core/mapper"
 )
 
 // MapperDef represents a Mapper, which is a collection of mappings
 type MapperDef struct {
-	//todo possibly add optional lang/mapper type so we can fast fail on unsupported mappings/mapper combo
 	Mappings []*data.MappingDef
 }
 
 type MapperFactory interface {
-
 	// NewMapper creates a new Mapper from the specified MapperDef
 	NewMapper(mapperDef *MapperDef) data.Mapper
 
@@ -37,211 +30,45 @@ type MapperFactory interface {
 
 var mapperFactory MapperFactory
 
-func SetMapperFactory(mapper MapperFactory) {
-	mapperFactory = mapper
+func SetMapperFactory(factory MapperFactory) {
+	mapperFactory = factory
+
+	baseFactory, ok := interface{}(factory).(mapper.Factory)
+	if ok {
+		mapper.SetFactory(baseFactory)
+	}
 }
 
 func GetMapperFactory() MapperFactory {
 
-	//temp hack until we fully move to new flow action model
+	//temp hack until we consolidate mapper definition
 	if mapperFactory == nil {
-		mapperFactory = &BasicMapperFactory{}
+		mapperFactory = &BasicMapperFactory{baseFactory: mapper.GetFactory()}
 	}
 
 	return mapperFactory
 }
 
-//todo move the following to flowAction
-
 type BasicMapperFactory struct {
+	baseFactory mapper.Factory
 }
 
 func (mf *BasicMapperFactory) NewMapper(mapperDef *MapperDef) data.Mapper {
-	return NewBasicMapper(mapperDef)
+	return mf.baseFactory.NewMapper(&data.MapperDef{Mappings: mapperDef.Mappings})
 }
 
 func (mf *BasicMapperFactory) NewTaskInputMapper(task *Task, mapperDef *MapperDef) data.Mapper {
-	return NewBasicMapper(mapperDef)
+	id := task.definition.name + "." + task.id + ".input"
+	return mf.baseFactory.NewUniqueMapper(id, &data.MapperDef{Mappings: mapperDef.Mappings})
 }
 
 func (mf *BasicMapperFactory) NewTaskOutputMapper(task *Task, mapperDef *MapperDef) data.Mapper {
-	return NewBasicMapper(mapperDef)
+	id := task.definition.name + "." + task.id + ".output"
+	return mf.baseFactory.NewUniqueMapper(id, &data.MapperDef{Mappings: mapperDef.Mappings})
 }
 
 func (mf *BasicMapperFactory) GetDefaultTaskOutputMapper(task *Task) data.Mapper {
 	return &DefaultOutputMapper{task: task}
-}
-
-// BasicMapper is a simple object holding and executing mappings
-type BasicMapper struct {
-	mappings []*data.MappingDef
-}
-
-// NewBasicMapper creates a new BasicMapper with the specified mappings
-func NewBasicMapper(mapperDef *MapperDef) data.Mapper {
-
-	var mapper BasicMapper
-	mapper.mappings = mapperDef.Mappings
-
-	return &mapper
-}
-
-// Mappings gets the mappings of the BasicMapper
-func (m *BasicMapper) Mappings() []*data.MappingDef {
-	return m.mappings
-}
-
-// Apply executes the mappings using the values from the input scope
-// and puts the results in the output scope
-//
-// return error
-func (m *BasicMapper) Apply(inputScope data.Scope, outputScope data.Scope) error {
-
-	//todo validate types
-	for _, mapping := range m.mappings {
-
-		switch mapping.Type {
-		case data.MtAssign:
-			var attrValue interface{}
-			var exists bool
-			var attrName string
-			// Get resolver type
-			resolType, err := data.GetResolverType(mapping.Value)
-			if err != nil {
-				return err
-			}
-
-			switch resolType {
-			// This is the Backward compatible case
-			case data.RES_DEFAULT:
-				attrName, attrPath, pathType := data.GetAttrPath(mapping.Value)
-				var tv *data.Attribute
-				tv, exists = inputScope.GetAttr(attrName)
-				if tv == nil {
-					err := fmt.Errorf("Failed to resolve attribute '%s' for mapping value '%s'", attrName, mapping.Value)
-					logger.Error(err.Error())
-					return err
-				}
-				attrValue = tv.Value
-				if exists && len(attrPath) > 0 {
-					if tv.Type == data.PARAMS {
-						valMap := attrValue.(map[string]string)
-						attrValue, exists = valMap[attrPath]
-					} else if tv.Type == data.ARRAY && pathType == data.PT_ARRAY {
-						//assigning part of array
-						idx, _ := strconv.Atoi(attrPath)
-						//todo handle err
-						if valArray, ok := attrValue.([]interface{}); ok {
-							attrValue = valArray[idx]
-						} else if valArray, ok := attrValue.([]string); ok {
-							attrValue = valArray[idx]
-						}
-					} else {
-						//for now assume if we have a path, attr is "object"
-						valMap := attrValue.(map[string]interface{})
-						attrValue = data.GetMapValue(valMap, attrPath)
-						//attrValue, exists = valMap[attrPath]
-					}
-				}
-			case data.RES_PROPERTY:
-				// Property resolution
-				attrValue, exists = property.Resolve(mapping.Value)
-				if !exists {
-					if attrName == "property" {
-						err := fmt.Errorf("Failed to resolve Property: '%s' mapped to the Attribute: '%s'. Ensure that property is configured in the application.", mapping.Value, mapping.MapTo)
-						logger.Error(err.Error())
-						return err
-					} else if attrName == "env" {
-						err := fmt.Errorf("Failed to resolve Environment Variable: '%s' mapped to the Attribute: '%s'. Ensure that variable is configured.", mapping.Value, mapping.MapTo)
-						logger.Error(err.Error())
-						return err
-					}
-				}
-			case data.RES_ACTIVITY:
-				// Activity resolution
-				attrValue, exists = activity.Resolve(inputScope, mapping.Value)
-				if !exists {
-					err := fmt.Errorf("Could not resolve expression '%s' for the current input scope", mapping.Value)
-					logger.Error(err.Error())
-					return err
-				}
-			case data.RES_TRIGGER:
-				// Trigger resolution
-				attrValue, exists = trigger.Resolve(inputScope, mapping.Value)
-				if !exists {
-					err := fmt.Errorf("Could not resolve expression '%s' for the current input scope", mapping.Value)
-					logger.Error(err.Error())
-					return err
-				}
-			}
-
-			//todo implement type conversion
-			if exists {
-				attrName, attrPath, pathType := data.GetAttrPath(mapping.MapTo)
-				toAttr, oe := outputScope.GetAttr(attrName)
-
-				if !oe {
-					return fmt.Errorf("Attr %s not found in output scope\n", attrName)
-				}
-
-				switch pathType {
-				case data.PT_SIMPLE:
-					outputScope.SetAttrValue(mapping.MapTo, attrValue)
-				case data.PT_ARRAY:
-					if toAttr.Type == data.ARRAY {
-						var valArray []interface{}
-						if toAttr.Value == nil {
-							//what should we do in this case, construct the array?
-							//valArray = make(map[string]string)
-						} else {
-							valArray = toAttr.Value.([]interface{})
-						}
-
-						idx, _ := strconv.Atoi(attrPath)
-						//todo handle err
-						valArray[idx] = attrValue
-
-						outputScope.SetAttrValue(attrName, valArray)
-					} else {
-						//todo throw error.. not an ARRAY
-					}
-				case data.PT_MAP:
-
-					if toAttr.Type == data.PARAMS {
-						var valMap map[string]string
-						if toAttr.Value == nil {
-							valMap = make(map[string]string)
-						} else {
-							valMap = toAttr.Value.(map[string]string)
-						}
-						strVal, _ := data.CoerceToString(attrValue)
-						valMap[attrPath] = strVal
-
-						outputScope.SetAttrValue(attrName, valMap)
-					} else if toAttr.Type == data.OBJECT {
-						var valMap map[string]interface{}
-						if toAttr.Value == nil {
-							valMap = make(map[string]interface{})
-						} else {
-							valMap = toAttr.Value.(map[string]interface{})
-						}
-						valMap[attrPath] = attrValue
-
-						outputScope.SetAttrValue(attrName, valMap)
-					} else {
-						//todo throw error.. not a OBJECT or PARAMS
-					}
-				}
-			}
-		//todo: should we ignore if DNE - if we have to add dynamically what type do we use
-		case data.MtLiteral:
-			outputScope.SetAttrValue(mapping.MapTo, mapping.Value)
-		case data.MtExpression:
-			//todo implement script mapping
-		}
-	}
-
-	return nil
 }
 
 // BasicMapper is a simple object holding and executing mappings
@@ -255,18 +82,14 @@ func (m *DefaultOutputMapper) Apply(inputScope data.Scope, outputScope data.Scop
 
 	act := activity.Get(m.task.ActivityRef())
 
-	attrNS := "{A" + m.task.ID() + "."
+	attrNS := "{A." + m.task.ID() + "."
 
-	attrNS2 := "${activity." + m.task.ID() + "."
-
-	for _, attr := range act.Metadata().Outputs {
+	for _, attr := range act.Metadata().Output {
 
 		oAttr, _ := inputScope.GetAttr(attr.Name)
 
 		if oAttr != nil {
-			// TODO remove the first attribute once we move to string ids
 			oscope.AddAttr(attrNS+attr.Name+"}", attr.Type, oAttr.Value)
-			oscope.AddAttr(attrNS2+attr.Name+"}", attr.Type, oAttr.Value)
 		}
 	}
 

--- a/trigger/cli/README.md
+++ b/trigger/cli/README.md
@@ -1,0 +1,117 @@
+# tibco-rest
+This trigger provides your flogo application the ability to start a flow via REST over HTTP
+
+## Installation
+
+```bash
+flogo add trigger github.com/TIBCOSoftware/flogo-contrib/trigger/rest
+```
+
+## Schema
+Settings, Outputs and Endpoint:
+
+```json
+{
+  "settings": [
+    {
+      "name": "port",
+      "type": "integer"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "pathParams",
+      "type": "params"
+    },
+    {
+      "name": "queryParams",
+      "type": "params"
+    },
+    {
+      "name": "content",
+      "type": "object"
+    }
+  ],
+  "endpoint": {
+    "settings": [
+      {
+        "name": "method",
+        "type": "string",
+        "required" : true
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "required" : true
+      }
+    ]
+  }
+}
+```
+## Settings
+### Trigger:
+| Setting     | Description    |
+|:------------|:---------------|
+| port | The port to listen on |         
+### Endpoint:
+| Setting     | Description    |
+|:------------|:---------------|
+| method      | The HTTP method |         
+| path        | The resource path  |
+
+
+## Example Configurations
+
+Triggers are configured via the triggers.json of your application. The following are some example configuration of the REST Trigger.
+
+### POST
+Configure the Trigger to handle a POST on /device
+
+```json
+{
+  "triggers": [
+    {
+      "name": "tibco-rest",
+      "settings": {
+        "port": "8080"
+      },
+      "endpoints": [
+        {
+          "actionType": "flow",
+          "actionURI": "embedded://new_device_flow",
+          "settings": {
+            "method": "POST",
+            "path": "/device"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### GET
+Configure the Trigger to handle a GET on /device/:id
+
+```json
+{
+  "triggers": [
+    {
+      "name": "tibco-rest",
+      "settings": {
+        "port": "8080"
+      },
+      "endpoints": [
+        {
+          "actionType": "flow",
+          "actionURI": "embedded://get_device_flow",
+          "settings": {
+            "method": "GET",
+            "path": "/device/:id"
+          }
+        }
+      ]
+    }
+  ]
+}
+```

--- a/trigger/cli/README.md
+++ b/trigger/cli/README.md
@@ -1,10 +1,10 @@
-# tibco-rest
+# tibco-cli
 This trigger provides your flogo application the ability to start a flow via REST over HTTP
 
 ## Installation
 
 ```bash
-flogo add trigger github.com/TIBCOSoftware/flogo-contrib/trigger/rest
+flogo install github.com/TIBCOSoftware/flogo-contrib/trigger/cli
 ```
 
 ## Schema
@@ -12,37 +12,21 @@ Settings, Outputs and Endpoint:
 
 ```json
 {
-  "settings": [
-    {
-      "name": "port",
-      "type": "integer"
-    }
-  ],
   "outputs": [
     {
-      "name": "pathParams",
-      "type": "params"
-    },
-    {
-      "name": "queryParams",
-      "type": "params"
-    },
-    {
-      "name": "content",
-      "type": "object"
+      "name": "args",
+      "type": "array"
     }
   ],
-  "endpoint": {
+  "handler": {
     "settings": [
       {
-        "name": "method",
-        "type": "string",
-        "required" : true
+        "name": "command",
+        "type": "string"
       },
       {
-        "name": "path",
-        "type": "string",
-        "required" : true
+        "name": "default",
+        "type": "bool"
       }
     ]
   }
@@ -50,68 +34,70 @@ Settings, Outputs and Endpoint:
 ```
 ## Settings
 ### Trigger:
+| Output     | Description    |
+|:------------|:---------------|
+| args | The array of arguments |         
+### Handler:
 | Setting     | Description    |
 |:------------|:---------------|
-| port | The port to listen on |         
-### Endpoint:
-| Setting     | Description    |
-|:------------|:---------------|
-| method      | The HTTP method |         
-| path        | The resource path  |
+| command      | The command invoked |         
+| default      | Indicates if its the default command  |
 
 
 ## Example Configurations
 
-Triggers are configured via the triggers.json of your application. The following are some example configuration of the REST Trigger.
+Triggers are configured via the triggers section of your application. The following are some example configuration of the CLI Trigger.
 
-### POST
-Configure the Trigger to handle a POST on /device
+### No command
+Configure the Trigger to execute one flow
 
 ```json
 {
-  "triggers": [
-    {
-      "name": "tibco-rest",
-      "settings": {
-        "port": "8080"
-      },
-      "endpoints": [
-        {
-          "actionType": "flow",
-          "actionURI": "embedded://new_device_flow",
-          "settings": {
-            "method": "POST",
-            "path": "/device"
+    "triggers": [
+      {
+        "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
+        "description": "Simple CLI trigger",
+        "settings": {},
+        "id": "main",
+        "handlers": [
+          {
+            "settings": {
+              "default": true
+            },
+            "actionId": "log_cli"
           }
-        }
-      ]
-    }
-  ]
+        ]
+      }
+    ]
 }
 ```
 
-### GET
-Configure the Trigger to handle a GET on /device/:id
+### Multiple Commands
+Configure the Trigger to handle multiple commands
 
 ```json
 {
-  "triggers": [
-    {
-      "name": "tibco-rest",
-      "settings": {
-        "port": "8080"
-      },
-      "endpoints": [
-        {
-          "actionType": "flow",
-          "actionURI": "embedded://get_device_flow",
-          "settings": {
-            "method": "GET",
-            "path": "/device/:id"
+    "triggers": [
+      {
+        "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
+        "description": "Simple CLI trigger",
+        "settings": {},
+        "id": "main",
+        "handlers": [
+          {
+            "settings": {
+              "command": "list"
+            },
+            "actionId": "list_flow"
+          },
+          {
+            "settings": {
+              "command": "run"
+            },
+            "actionId": "run_flow"
           }
-        }
-      ]
-    }
-  ]
+        ]
+      }
+    ]
 }
 ```

--- a/trigger/cli/main.entrypoint
+++ b/trigger/cli/main.entrypoint
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+    "github.com/TIBCOSoftware/flogo-contrib/trigger/cli"
+)
+
+func main() {
+	result := cli.Invoke()
+	fmt.Fprintf(os.Stdout, "%s", result)
+	os.Exit(0)
+}

--- a/trigger/cli/main.entrypoint
+++ b/trigger/cli/main.entrypoint
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	result := cli.Invoke()
+	result,_ := cli.Invoke()
 	fmt.Fprintf(os.Stdout, "%s", result)
 	os.Exit(0)
 }

--- a/trigger/cli/shim/shim.go
+++ b/trigger/cli/shim/shim.go
@@ -1,4 +1,4 @@
-package main
+package shim
 
 import (
 	"fmt"

--- a/trigger/cli/shim/shim.go
+++ b/trigger/cli/shim/shim.go
@@ -1,4 +1,4 @@
-package shim
+package main
 
 import (
 	"fmt"

--- a/trigger/cli/trigger.go
+++ b/trigger/cli/trigger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"reflect"
+	"encoding/json"
 )
 
 // log is the default package logger
@@ -145,7 +146,11 @@ func (t *CliTrigger) Invoke(actionId string, args []string) (string, error) {
 	}
 
 	if replyData != nil {
-		return replyData.(string), nil
+		data, err := json.Marshal(replyData)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
 	}
 
 	return "", nil

--- a/trigger/cli/trigger.go
+++ b/trigger/cli/trigger.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"reflect"
 	"encoding/json"
+	"github.com/TIBCOSoftware/flogo-lib/config"
 )
 
 // log is the default package logger
@@ -54,6 +55,12 @@ func (t *CliTrigger) Metadata() *trigger.Metadata {
 }
 
 func (t *CliTrigger) Init(runner action.Runner) {
+
+	level, err := logger.GetLevelForName(config.GetLogLevel())
+
+	if err == nil {
+		log.SetLogLevel(level)
+	}
 
 	if t.config.Settings == nil {
 		panic(fmt.Sprintf("No Settings found for trigger '%s'", t.config.Id))

--- a/trigger/cli/trigger.go
+++ b/trigger/cli/trigger.go
@@ -1,0 +1,145 @@
+package rest
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/action"
+	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+)
+
+
+// log is the default package logger
+var log = logger.GetLogger("trigger-tibco-cli")
+
+var singleton *CliTrigger
+
+// CliTrigger CLI trigger struct
+type CliTrigger struct {
+	metadata *trigger.Metadata
+	runner   action.Runner
+	config   *trigger.Config
+	actions  []*actionInfo
+	defAction *actionInfo
+}
+
+type actionInfo struct {
+	actionId string
+	invoke   bool
+}
+
+//NewFactory create a new Trigger factory
+func NewFactory(md *trigger.Metadata) trigger.Factory {
+	return &CliTriggerFactory{metadata: md}
+}
+
+// CliTriggerFactory CLI Trigger factory
+type CliTriggerFactory struct {
+	metadata *trigger.Metadata
+}
+
+//New Creates a new trigger instance for a given id
+func (t *CliTriggerFactory) New(config *trigger.Config) trigger.Trigger {
+	singleton := &CliTrigger{metadata: t.metadata, config: config}
+
+	return singleton
+}
+
+// Metadata implements trigger.Trigger.Metadata
+func (t *CliTrigger) Metadata() *trigger.Metadata {
+	return t.metadata
+}
+
+func (t *CliTrigger) Init(runner action.Runner) {
+
+	if t.config.Settings == nil {
+		panic(fmt.Sprintf("No Settings found for trigger '%s'", t.config.Id))
+	}
+
+	if len(t.config.Handlers) == 0 {
+		panic(fmt.Sprintf("No Handlers found for trigger '%s'", t.config.Id))
+	}
+
+	t.runner = runner
+	hasDefault := false
+
+	// Init handlers
+	for _, handlerCfg := range t.config.Handlers {
+
+		cmdString := "default"
+
+		aInfo := &actionInfo{actionId:handlerCfg.ActionId, invoke:false}
+		if cmd, ok := handlerCfg.Settings["command"]; ok {
+			cmdString = cmd.(string)
+		}
+
+		if cmd, set := handlerCfg.Settings["default"]; set {
+			if def, ok := cmd.(bool); ok && def {
+				t.defAction = aInfo
+				hasDefault = true
+			}
+		}
+
+		t.actions = append(t.actions, aInfo)
+		flag.BoolVar(aInfo.&invoke, cmdString, false, "")
+	}
+
+	if !hasDefault {
+		t.defAction = t.actions[0]
+	}
+}
+
+func (t *CliTrigger) Start() error {
+	return nil
+}
+
+// Stop implements util.Managed.Stop
+func (t *CliTrigger) Stop() error {
+	return nil
+}
+
+func Invoke() (string,error) {
+
+	flag.Parse()
+	args := flag.Args()
+
+	for _, value := range singleton.actions {
+
+		if value.invoke {
+			return singleton.Invoke(value.actionId, args)
+		}
+	}
+
+	return singleton.Invoke(singleton.defAction.actionId, args)
+}
+
+func (t *CliTrigger) Invoke(actionId string, args []string) (string,error) {
+
+	log.Infof("CLI Trigger: Invoking action '%s'", actionId)
+
+	data := map[string]interface{}{
+		"args":      args,
+	}
+
+	//todo handle error
+	startAttrs, _ := t.metadata.OutputsToAttrs(data, false)
+
+	act := action.Get(actionId)
+	log.Debugf("Found action' %+x'", act)
+
+	ctx := trigger.NewContext(context.Background(), startAttrs)
+	_, replyData, err := t.runner.Run(ctx, act, actionId, nil)
+
+	if err != nil {
+		log.Debugf("CLI Trigger Error: %s", err.Error())
+		return "", err
+	}
+
+	if replyData != nil {
+		return replyData.(string), nil
+	}
+
+	return "", nil
+}

--- a/trigger/cli/trigger.go
+++ b/trigger/cli/trigger.go
@@ -1,4 +1,4 @@
-package rest
+package cli
 
 import (
 	"context"

--- a/trigger/cli/trigger.go
+++ b/trigger/cli/trigger.go
@@ -27,7 +27,7 @@ type CliTrigger struct {
 
 type actionInfo struct {
 	actionId string
-	invoke   bool
+	Invoke   bool
 }
 
 //NewFactory create a new Trigger factory
@@ -70,7 +70,7 @@ func (t *CliTrigger) Init(runner action.Runner) {
 
 		cmdString := "default"
 
-		aInfo := &actionInfo{actionId: handlerCfg.ActionId, invoke: false}
+		aInfo := &actionInfo{actionId: handlerCfg.ActionId, Invoke: false}
 		if cmd, ok := handlerCfg.Settings["command"]; ok {
 			cmdString = cmd.(string)
 		}
@@ -85,7 +85,7 @@ func (t *CliTrigger) Init(runner action.Runner) {
 		t.actions = append(t.actions, aInfo)
 
 		xv := reflect.ValueOf(aInfo).Elem()
-		addr := xv.FieldByName("invoke").Addr().Interface()
+		addr := xv.FieldByName("Invoke").Addr().Interface()
 
 		switch ptr := addr.(type) {
 		case *bool:
@@ -114,7 +114,7 @@ func Invoke() (string, error) {
 
 	for _, value := range singleton.actions {
 
-		if value.invoke {
+		if value.Invoke {
 			return singleton.Invoke(value.actionId, args)
 		}
 	}

--- a/trigger/cli/trigger.json
+++ b/trigger/cli/trigger.json
@@ -1,0 +1,28 @@
+{
+  "name": "tibco-cli",
+  "type": "flogo:trigger",
+  "entrypoint":"main",
+  "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
+  "version": "0.0.1",
+  "title": "CLI Trigger",
+  "description": "Simple CLI Trigger",
+  "homepage": "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/trigger/cli",
+  "outputs": [
+    {
+      "name": "args",
+      "type": "array"
+    }
+  ],
+  "handler": {
+    "settings": [
+      {
+        "name": "command",
+        "type": "string"
+      },
+      {
+        "name": "default",
+        "type": "bool"
+      }
+    ]
+  }
+}

--- a/trigger/cli/trigger.json
+++ b/trigger/cli/trigger.json
@@ -1,7 +1,7 @@
 {
   "name": "tibco-cli",
   "type": "flogo:trigger",
-  "entrypoint":"main",
+  "shim": "main",
   "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
   "version": "0.0.1",
   "title": "CLI Trigger",

--- a/trigger/cli/trigger_test.go
+++ b/trigger/cli/trigger_test.go
@@ -59,7 +59,7 @@ func (tr *TestRunner) Run(context context.Context, action action.Action, uri str
 func TestInitOk(t *testing.T) {
 	// New  factory
 	f := &CliTriggerFactory{}
-	tgr := f.New("tibco-rest")
+	tgr := f.New("tibco-cli")
 
 	runner := &TestRunner{}
 

--- a/trigger/cli/trigger_test.go
+++ b/trigger/cli/trigger_test.go
@@ -1,0 +1,106 @@
+package rest
+
+import (
+	"context"
+	//"encoding/json"
+	//"net/http"
+	//"testing"
+	"io/ioutil"
+
+	"github.com/TIBCOSoftware/flogo-lib/core/action"
+	//"github.com/TIBCOSoftware/flogo-lib/core/trigger"
+	"testing"
+	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
+	"net/http"
+)
+
+var jsonMetadata = getJsonMetadata()
+
+func getJsonMetadata() string {
+	jsonMetadataBytes, err := ioutil.ReadFile("trigger.json")
+	if err != nil {
+		panic("No Json Metadata found for trigger.json path")
+	}
+	return string(jsonMetadataBytes)
+}
+
+const testConfig string = `{
+  "id": "tibco-cli",
+  "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
+  "handlers": [
+    {
+      "actionId": "",
+      "settings": {
+        "command": "run",
+        "default": "true"
+      }
+    },
+    {
+      "actionId": "version_flow",
+      "settings": {
+        "command": "version"
+      }
+    }
+  ]
+}
+`
+
+type TestRunner struct {
+}
+
+// Run implements action.Runner.Run
+func (tr *TestRunner) Run(context context.Context, action action.Action, uri string, options interface{}) (code int, data interface{}, err error) {
+	log.Debugf("Ran Action: %v", uri)
+	return 0, nil, nil
+}
+
+/*
+//TODO fix this test
+func TestInitOk(t *testing.T) {
+	// New  factory
+	f := &CliTriggerFactory{}
+	tgr := f.New("tibco-rest")
+
+	runner := &TestRunner{}
+
+	config := trigger.Config{}
+	json.Unmarshal([]byte(testConfig), &config)
+	tgr.Init(config, runner)
+}
+*/
+
+/*
+//TODO fix this test
+func TestHandlerOk(t *testing.T) {
+
+	// New  factory
+	f := &CliTriggerFactory{}
+	tgr := f.New("tibco-cli")
+
+	runner := &TestRunner{}
+
+	config := trigger.Config{}
+	tgr.Init(runner)
+
+	tgr.Start()
+	defer tgr.Stop()
+
+	uri := "http://127.0.0.1:8091/device/12345/reset"
+
+	req, err := http.NewRequest("POST", uri, nil)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	log.Debug("response Status:", resp.Status)
+
+	if resp.StatusCode >= 300 {
+		t.Fail()
+	}
+}
+*/
+

--- a/trigger/cli/trigger_test.go
+++ b/trigger/cli/trigger_test.go
@@ -1,4 +1,4 @@
-package rest
+package cli
 
 import (
 	"context"


### PR DESCRIPTION
Add "shim" CLI triggers  A trigger with a shim is one that can bypass the regular engine hosting and control how it is invoked.  Directly through its own main or as a plugin.

When an app has a trigger with a shim, that shim can be specified to be used in the build step using the trigger id of the trigger with the shim:

```flogo build -shim <triggerId>```

Shims can be set on a trigger by adding "shim":"main" (specifies its own main) or "shim":"plugin" (indicating that the shim entrypoint is via a go plugin).  The trigger should also contain a "shim" directory with its necessary support file.  

```
	shim/shim.go   <-- for plugin or main
	shim/Makefile  <-- if plugin type, for now looks for "Makefile" that will be invoked at build time
```