### PR TITLE
issue #118 replyTo attribute updated to remove flow deadloack

### DIFF
--- a/trigger/mqtt/trigger.go
+++ b/trigger/mqtt/trigger.go
@@ -136,6 +136,7 @@ func (t *MqttTrigger) RunAction(actionURI string, payload string) {
 	//	log.Error("Error Starting action ", err.Error())
 	//	return
 	//}
+	req.ReplyTo = t.config.GetSetting("topic")
 
 	//todo handle error
 	startAttrs, _ := t.metadata.OutputsToAttrs(req.Data, false)


### PR DESCRIPTION
- Added statement to update **StartRequest.ReplyTo** struct to remove deadlock

**Issue:** As topic attribute defined in trigger's input section is not getting updated in **StartRequest.ReplyTo** struct. mqtt trigger is was not getting topic name to respond with, leading to flow deadlock.
![image](https://user-images.githubusercontent.com/8110509/32378415-ba97f92a-c0d0-11e7-976c-dfe36aeecfc7.png)
