### PR TITLE
cleanup resolver and support for direct object mapping

### DIFF
--- a/action/flow/definition/mapper.go
+++ b/action/flow/definition/mapper.go
@@ -54,17 +54,17 @@ type BasicMapperFactory struct {
 }
 
 func (mf *BasicMapperFactory) NewMapper(mapperDef *MapperDef) data.Mapper {
-	return mf.baseFactory.NewMapper(&data.MapperDef{Mappings: mapperDef.Mappings})
+	return mf.baseFactory.NewMapper(&data.MapperDef{Mappings: mapperDef.Mappings}, GetDataResolver())
 }
 
 func (mf *BasicMapperFactory) NewTaskInputMapper(task *Task, mapperDef *MapperDef) data.Mapper {
 	id := task.definition.name + "." + task.id + ".input"
-	return mf.baseFactory.NewUniqueMapper(id, &data.MapperDef{Mappings: mapperDef.Mappings})
+	return mf.baseFactory.NewUniqueMapper(id, &data.MapperDef{Mappings: mapperDef.Mappings}, GetDataResolver())
 }
 
 func (mf *BasicMapperFactory) NewTaskOutputMapper(task *Task, mapperDef *MapperDef) data.Mapper {
 	id := task.definition.name + "." + task.id + ".output"
-	return mf.baseFactory.NewUniqueMapper(id, &data.MapperDef{Mappings: mapperDef.Mappings})
+	return mf.baseFactory.NewUniqueMapper(id, &data.MapperDef{Mappings: mapperDef.Mappings}, nil)
 }
 
 func (mf *BasicMapperFactory) GetDefaultTaskOutputMapper(task *Task) data.Mapper {

--- a/action/flow/definition/resolve.go
+++ b/action/flow/definition/resolve.go
@@ -1,0 +1,92 @@
+package definition
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
+)
+
+var resolver = &FlowResolver{}
+
+func GetDataResolver() data.Resolver {
+	return resolver
+}
+
+type FlowResolver struct {
+}
+
+func (r *FlowResolver) Resolve(toResolve string, scope data.Scope) (value interface{}, err error){
+
+	var details *data.ResolutionDetails
+
+	if strings.HasPrefix(toResolve,"${") {
+		details,err = data.GetResolutionDetailsOld(toResolve)
+	} else if strings.HasPrefix(toResolve, "$") {
+		details,err = data.GetResolutionDetails(toResolve[1:])
+	} else {
+		return data.SimpleScopeResolve(toResolve, scope)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if details == nil {
+		return nil, fmt.Errorf("unable to determine resolver for %s", toResolve)
+	}
+
+	var exists bool
+
+	switch details.ResolverName {
+	case "property":
+		// Property resolution
+		provider := data.GetPropertyProvider()
+		value, exists = provider.GetProperty(details.Property + details.Path) //should we add the path and reset it to ""
+		if !exists {
+			err := fmt.Errorf("failed to resolve Property: '%s', ensure that property is configured in the application", details.Property)
+			logger.Error(err.Error())
+			return nil, err
+		}
+	case "env":
+		// Environment resolution
+		value, exists = os.LookupEnv(details.Property + details.Path)
+		if !exists {
+			err := fmt.Errorf("failed to resolve Environment Variable: '%s', ensure that variable is configured", details.Property)
+			logger.Error(err.Error())
+			return "", err
+		}
+	case "activity":
+		attr, exists := scope.GetAttr("_A." + details.Item + "." +details.Property)
+		if !exists {
+			return nil, fmt.Errorf("failed to resolve activity attr: '%s', not found in flow", details.Property)
+		}
+		value = attr.Value
+	case "trigger":
+		attr, exists := scope.GetAttr("_T." + details.Property)
+		if !exists {
+			return nil, fmt.Errorf("failed to resolve trigger attr: '%s', not found in flow", details.Property)
+		}
+		value = attr.Value
+	case "flow":
+		attr, exists := scope.GetAttr(details.Property)
+		if !exists {
+			return nil, fmt.Errorf("failed to resolve flow attr: '%s', not found in flow", details.Property)
+		}
+		value = attr.Value
+	default:
+		return nil, fmt.Errorf("unsupported resolver: %s", details.ResolverName)
+	}
+
+	if details.Path != "" {
+		value, err = data.PathGetValue(value, details.Path)
+		if err != nil {
+			logger.Error(err.Error())
+			return nil, err
+		}
+	}
+
+	return value, nil
+}

--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -558,6 +558,15 @@ func (pi *Instance) GetAttr(attrName string) (value *data.Attribute, exists bool
 	return pi.Flow.GetAttr(attrName)
 }
 
+func (pi *Instance) getInstAttr(attrName string) (value *data.Attribute, exists bool) {
+
+	if pi.Attrs != nil {
+		attr, found := pi.Attrs[attrName]
+		return attr, found
+	}
+	return nil, false
+}
+
 // SetAttrValue implements api.Scope.SetAttrValue
 func (pi *Instance) SetAttrValue(attrName string, value interface{}) error {
 	if pi.Attrs == nil {
@@ -624,10 +633,6 @@ func (ac *ActionCtx) InstanceMetadata() *action.ConfigMetadata {
 	return ac.config.Metadata
 }
 
-//func (ac *ActionCtx) Reply(data map[string]interface{}, err error) {
-//	ac.rh.HandleResult(data, err)
-//}
-
 func (ac *ActionCtx) Reply(replyData map[string]*data.Attribute, err error) {
 	ac.rh.HandleResult(replyData, err)
 }
@@ -640,6 +645,11 @@ func (ac *ActionCtx) Return(returnData map[string]*data.Attribute, err error) {
 
 func (ac *ActionCtx) WorkingData() data.Scope {
 	return ac.inst
+}
+
+
+func (ac *ActionCtx) GetResolver() data.Resolver {
+	return definition.GetDataResolver()
 }
 
 func (pi *Instance) GetReturnData()  (map[string]*data.Attribute, error) {
@@ -1181,3 +1191,4 @@ func NewWorkItem(id int, taskData *TaskData, execType ExecType, evalCode int) *W
 
 	return &workItem
 }
+

--- a/action/flow/script/fggos/linkexpr.go
+++ b/action/flow/script/fggos/linkexpr.go
@@ -10,7 +10,6 @@ import (
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/definition"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
-	"github.com/TIBCOSoftware/flogo-lib/core/mapper"
 )
 
 // GosLinkExprManager is the Lua Implementation of a Link Expression Manager
@@ -162,9 +161,9 @@ func (em *GosLinkExprManager) EvalLinkExpr(link *definition.Link, scope data.Sco
 
 	for _, varRep := range vars {
 
-		lookupExpr := mapper.NewLookupExpr(varRep)
+		resolver := definition.GetDataResolver()
 
-		val, err := lookupExpr.Eval(scope)
+		val, err := resolver.Resolve(varRep, scope)
 
 		if err == nil {
 			//	return false, err
@@ -257,9 +256,9 @@ type isDefinedFunc struct {
 }
 
 func (f *isDefinedFunc) isDefined(value string) bool {
-	lookupExpr := mapper.NewLookupExpr(value)
 
-	_, err := lookupExpr.Eval(f.scope)
+	resolver := definition.GetDataResolver()
+	_, err := resolver.Resolve(value, f.scope)
 
 	return err == nil
 }

--- a/activity/actreply/activity.go
+++ b/activity/actreply/activity.go
@@ -42,7 +42,7 @@ func (a *ReplyActivity) Eval(ctx activity.Context) (done bool, err error) {
 	mapperDef, err := mapper.NewMapperDefFromAnyArray(mappings)
 
 	//todo move this to a action instance level initialization, need the notion of static inputs or config
-	replyMapper := mapper.NewBasicMapper(mapperDef)
+	replyMapper := mapper.NewBasicMapper(mapperDef, ctx.ActionContext().GetResolver())
 
 	if err != nil {
 		return false, nil

--- a/activity/actreturn/activity.go
+++ b/activity/actreturn/activity.go
@@ -42,7 +42,7 @@ func (a *ReturnActivity) Eval(ctx activity.Context) (done bool, err error) {
 	mapperDef, err := mapper.NewMapperDefFromAnyArray(mappings)
 
 	//todo move this to a action instance level initialization, need the notion of static inputs or config
-	returnMapper := mapper.NewBasicMapper(mapperDef)
+	returnMapper := mapper.NewBasicMapper(mapperDef, ctx.ActionContext().GetResolver())
 
 	if err != nil {
 		return false, nil

--- a/activity/reply/activity.json
+++ b/activity/reply/activity.json
@@ -6,6 +6,7 @@
   "title": "Reply To Trigger",
   "description": "Simple Reply Activity",
   "homepage": "https://github.com/TIBCOSoftware/flogo-contrib/tree/master/activity/reply",
+  "reply": true,
   "inputs":[
     {
       "name": "code",


### PR DESCRIPTION
Updated resolvers and added object mapping.   Requires flow attribute resolution to be ${flow.attr} or $flow.attr from just ${attr}.  Needs to be updated in the UI.  Format for expressions in object mapping is : "{{ expr }}".  For now we are only supporting simple assignment, i.e. "{{$flow.inputParams.petId}}", "{{$activity[rest1].content}}" or "{{$activity.rest1.content}}".  For activities I prefer the first style, but I'll let you guys weigh in.

example object mapping:
```
{
  "type": 4,
  "value": {
    "pet": {
      "type": "NONE",
      "id": "{{$flow.inputParams.petId}}",
      "embeddable": false,
      "epub": {
        "isAvailable": false
      },
      "pdf": {
        "isAvailable": false
      }
    }
  }
}
```
