### PR TITLE
the data field for reply should be any.

### DIFF
--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -306,7 +306,7 @@ type SimpleReplyHandler struct {
 // Reply implements ReplyHandler.Reply
 func (rh *SimpleReplyHandler) Reply(code int, replyData interface{}, err error) {
 
-	dataAttr, _ := data.NewAttribute("data", data.TypeObject, replyData)
+	dataAttr, _ := data.NewAttribute("data", data.TypeAny, replyData)
 	codeAttr, _ := data.NewAttribute("code", data.TypeInteger, code)
 	resultData := map[string]*data.Attribute{
 		"data": dataAttr,


### PR DESCRIPTION
For WI case we define reply activity data field as complex_object type so it can reply back with any data type.  

It can be `string literal` or `json object` or `array`, changed the type to `any` would be good to handle those cases