### PR TITLE
Avoid to shceduleEval task while it is a skipped status

### DIFF
--- a/action/flow/instance/instances.go
+++ b/action/flow/instance/instances.go
@@ -443,7 +443,7 @@ func (inst *IndependentInstance) enterTasks(activeInst *Instance, taskEntries []
 			inst.scheduleEval(enterTaskData)
 		} else if enterResult == model.ENTER_SKIP {
 			//todo optimize skip, just keep skipping and don't schedule eval
-			inst.scheduleEval(enterTaskData)
+			//inst.scheduleEval(enterTaskData)
 		}
 	}
 }


### PR DESCRIPTION
This issue cause linker condition false but the branch flow also gets run. 