### PR TITLE
Add error handler resolver

### DIFF
--- a/action/flow/definition/resolve.go
+++ b/action/flow/definition/resolve.go
@@ -64,6 +64,12 @@ func (r *FlowResolver) Resolve(toResolve string, scope data.Scope) (value interf
 			return nil, fmt.Errorf("failed to resolve activity attr: '%s', not found in flow", details.Property)
 		}
 		value = attr.Value()
+	case "error":
+		attr, exists := scope.GetAttr("_E." + details.Property)
+		if !exists {
+			return nil, fmt.Errorf("failed to resolve error attr: '%s', not found in flow", details.Property)
+		}
+		value = attr.Value()
 	case "trigger":
 		attr, exists := scope.GetAttr("_T." + details.Property)
 		if !exists {

--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -108,22 +108,22 @@ func (inst *Instance) appendErrorData(err error) {
 
 	switch e := err.(type) {
 	case *definition.LinkExprError:
-		inst.AddAttr("{Error.type}", data.TypeString, "link_expr")
-		inst.AddAttr("{Error.message}", data.TypeString, err.Error())
+		inst.AddAttr("_E.type", data.TypeString, "link_expr")
+		inst.AddAttr("_E.message", data.TypeString, err.Error())
 	case *activity.Error:
-		inst.AddAttr("{Error.message}", data.TypeString, err.Error())
-		inst.AddAttr("{Error.data}", data.TypeObject, e.Data())
-		inst.AddAttr("{Error.code}", data.TypeString, e.Code())
+		inst.AddAttr("_E.message", data.TypeString, err.Error())
+		inst.AddAttr("_E.data", data.TypeObject, e.Data())
+		inst.AddAttr("_E.code", data.TypeString, e.Code())
 
 		if e.ActivityName() != "" {
-			inst.AddAttr("{Error.activity}", data.TypeString, e.ActivityName())
+			inst.AddAttr("_E.activity", data.TypeString, e.ActivityName())
 		}
 	case *ActivityEvalError:
-		inst.AddAttr("{Error.activity}", data.TypeString, e.TaskName())
-		inst.AddAttr("{Error.message}", data.TypeString, err.Error())
-		inst.AddAttr("{Error.type}", data.TypeString, e.Type())
+		inst.AddAttr("_E.activity", data.TypeString, e.TaskName())
+		inst.AddAttr("_E.message", data.TypeString, err.Error())
+		inst.AddAttr("_E.type", data.TypeString, e.Type())
 	default:
-		inst.AddAttr("{Error.message}", data.TypeString, err.Error())
+		inst.AddAttr("_E.message", data.TypeString, err.Error())
 	}
 
 	//todo add case for *dataMapperError & *activity.Error


### PR DESCRIPTION
Now it has the issue to resolve error handler details.  such as:{error.message} or $error.message.

I raised this pull request to add `error` resolver and change error attribute name to `_E.attrs` to keep same with activity and trigger(`_A.` and` _T.`).

@fm-tibco The PR might not good.  we need more thoughts from you.