### PR TITLE
importing aws-lambda-go in trigger.go to resolve dep issue

### DIFF
--- a/trigger/lambda/trigger.go
+++ b/trigger/lambda/trigger.go
@@ -9,6 +9,9 @@ import (
 	"github.com/TIBCOSoftware/flogo-lib/core/action"
 	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
+
+	// Import the aws-lambda-go. Required for dep to pull on app create
+	_ "github.com/aws/aws-lambda-go/lambda"
 )
 
 // log is the default package logger


### PR DESCRIPTION
Because the import happens in shim.go, which is not part of the dep tree on app create, the package will not be pulled in by go dep. adding a blank import to trigger.go to resolve this issue