### PR TITLE
rest invoke activity: optional param to skip ssl validation

### DIFF
--- a/activity/rest/activity.json
+++ b/activity/rest/activity.json
@@ -36,6 +36,11 @@
       "type": "params"
     },
     {
+      "name": "skipSsl",
+      "type": "boolean",
+      "value": "false"
+    },
+    {
       "name": "content",
       "type": "any"
     }

--- a/activity/rest/activity_test.go
+++ b/activity/rest/activity_test.go
@@ -74,7 +74,7 @@ func TestSimpleGet(t *testing.T) {
 
 	//setup attrs
 	tc.SetInput("method", "GET")
-	tc.SetInput("uri", "http://petstore.swagger.io/v2/pet/1")
+	tc.SetInput("uri", "http://petstore.swagger.io/v2/pet/16")
 
 	//eval
 	act.Eval(tc)


### PR DESCRIPTION
Adding an optional param to skip ssl validation during rest invoke. ideally, this should not be used for anything other than testing. the root certs should be added to the host in an ideal world.

reference: TIBCOSoftware/flogo#192