### PR TITLE
Set activity name to task name

### DIFF
--- a/action/flow/definition/definition_ser.go
+++ b/action/flow/definition/definition_ser.go
@@ -50,6 +50,7 @@ type TaskRep struct {
 
 // ActivityConfigRep is a serializable representation of an activity configuration
 type ActivityConfigRep struct {
+	Name        string                 `json:"name"`
 	Ref         string                 `json:"ref"`
 	Mappings    *Mappings              `json:"mappings,omitempty"`
 	Settings    map[string]interface{} `json:"settings"`
@@ -195,6 +196,10 @@ func createTask(def *Definition, rep *TaskRep) (*Task, error) {
 			def.explicitReply = true
 		}
 
+		if task.name == "" {
+			task.name = rep.ActivityCfgRep.Name
+		}
+
 		task.activityCfg = actCfg
 	}
 
@@ -214,7 +219,7 @@ func createActivityConfig(task *Task, rep *ActivityConfigRep) (*ActivityConfig, 
 
 	activityCfg := &ActivityConfig{}
 	activityCfg.Activity = act
-
+	
 	//todo need to fix this
 	task.activityCfg = activityCfg
 


### PR DESCRIPTION
The activity name is not correctly set at runtime.  Hence, context.Name() returns empty string instead of the name.