### PR TITLE
Constructing error attributes based on current task

### DIFF
--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -104,31 +104,6 @@ func (inst *Instance) releaseTask(task *definition.Task) {
 	}
 }
 
-func (inst *Instance) appendErrorData(err error) {
-
-	switch e := err.(type) {
-	case *definition.LinkExprError:
-		inst.AddAttr("_E.type", data.TypeString, "link_expr")
-		inst.AddAttr("_E.message", data.TypeString, err.Error())
-	case *activity.Error:
-		inst.AddAttr("_E.message", data.TypeString, err.Error())
-		inst.AddAttr("_E.data", data.TypeObject, e.Data())
-		inst.AddAttr("_E.code", data.TypeString, e.Code())
-
-		if e.ActivityName() != "" {
-			inst.AddAttr("_E.activity", data.TypeString, e.ActivityName())
-		}
-	case *ActivityEvalError:
-		inst.AddAttr("_E.activity", data.TypeString, e.TaskName())
-		inst.AddAttr("_E.message", data.TypeString, err.Error())
-		inst.AddAttr("_E.type", data.TypeString, e.Type())
-	default:
-		inst.AddAttr("_E.message", data.TypeString, err.Error())
-	}
-
-	//todo add case for *dataMapperError & *activity.Error
-}
-
 /////////////////////////////////////////
 // Instance - activity.Host Implementation
 

--- a/action/flow/instance/instances.go
+++ b/action/flow/instance/instances.go
@@ -210,7 +210,7 @@ func (inst *IndependentInstance) execTask(behavior model.TaskBehavior, taskInst 
 
 			if !taskInst.flowInst.isHandlingError {
 
-				taskInst.flowInst.appendErrorData(NewActivityEvalError(taskInst.task.Name(), "unhandled", err.Error()))
+				taskInst.appendErrorData(NewActivityEvalError(taskInst.task.Name(), "unhandled", err.Error()))
 				inst.HandleGlobalError(taskInst.flowInst, err)
 			}
 			// else what should we do?
@@ -268,7 +268,7 @@ func (inst *IndependentInstance) handleTaskDone(taskBehavior model.TaskBehavior,
 	containerInst := taskInst.flowInst
 
 	if err != nil {
-		containerInst.appendErrorData(err)
+		taskInst.appendErrorData(err)
 		inst.HandleGlobalError(containerInst, err)
 		return
 	}
@@ -343,7 +343,7 @@ func (inst *IndependentInstance) handleTaskError(taskBehavior model.TaskBehavior
 			//fail
 			inst.SetStatus(model.FlowStatusFailed)
 		} else {
-			containerInst.appendErrorData(err)
+			taskInst.appendErrorData(err)
 			inst.HandleGlobalError(containerInst, err)
 		}
 		return

--- a/action/flow/instance/taskinst.go
+++ b/action/flow/instance/taskinst.go
@@ -457,6 +457,33 @@ func (ti *TaskInst) FlowReturn(returnData map[string]*data.Attribute, err error)
 	}
 }
 
+func (taskInst *TaskInst) appendErrorData(err error) {
+
+	switch e := err.(type) {
+	case *definition.LinkExprError:
+		taskInst.flowInst.AddAttr("_E.type", data.TypeString, "link_expr")
+		taskInst.flowInst.AddAttr("_E.message", data.TypeString, err.Error())
+	case *activity.Error:
+		taskInst.flowInst.AddAttr("_E.message", data.TypeString, err.Error())
+		taskInst.flowInst.AddAttr("_E.data", data.TypeObject, e.Data())
+		taskInst.flowInst.AddAttr("_E.code", data.TypeString, e.Code())
+
+		if e.ActivityName() != "" {
+			taskInst.flowInst.AddAttr("_E.activity", data.TypeString, e.ActivityName())
+		} else {
+			taskInst.flowInst.AddAttr("_E.activity", data.TypeString, taskInst.Name())
+		}
+	case *ActivityEvalError:
+		taskInst.flowInst.AddAttr("_E.activity", data.TypeString, e.TaskName())
+		taskInst.flowInst.AddAttr("_E.message", data.TypeString, err.Error())
+		taskInst.flowInst.AddAttr("_E.type", data.TypeString, e.Type())
+	default:
+		taskInst.flowInst.AddAttr("_E.activity", data.TypeString, taskInst.Name())
+		taskInst.flowInst.AddAttr("_E.message", data.TypeString, err.Error())
+	}
+
+	//todo add case for *dataMapperError & *activity.Error
+}
 //// Failed marks the Activity as failed
 //func (td *TaskInst) Failed(err error) {
 //

--- a/action/flow/instance/taskinst.go
+++ b/action/flow/instance/taskinst.go
@@ -17,6 +17,7 @@ func NewTaskInst(inst *Instance, task *definition.Task) *TaskInst {
 
 	taskInst.flowInst = inst
 	taskInst.task = task
+	taskInst.taskID = task.ID()
 	return &taskInst
 }
 
@@ -471,14 +472,14 @@ func (taskInst *TaskInst) appendErrorData(err error) {
 		if e.ActivityName() != "" {
 			taskInst.flowInst.AddAttr("_E.activity", data.TypeString, e.ActivityName())
 		} else {
-			taskInst.flowInst.AddAttr("_E.activity", data.TypeString, taskInst.Name())
+			taskInst.flowInst.AddAttr("_E.activity", data.TypeString, taskInst.taskID)
 		}
 	case *ActivityEvalError:
 		taskInst.flowInst.AddAttr("_E.activity", data.TypeString, e.TaskName())
 		taskInst.flowInst.AddAttr("_E.message", data.TypeString, err.Error())
 		taskInst.flowInst.AddAttr("_E.type", data.TypeString, e.Type())
 	default:
-		taskInst.flowInst.AddAttr("_E.activity", data.TypeString, taskInst.Name())
+		taskInst.flowInst.AddAttr("_E.activity", data.TypeString, taskInst.taskID)
 		taskInst.flowInst.AddAttr("_E.message", data.TypeString, err.Error())
 	}
 


### PR DESCRIPTION
Today, no activity name is set for generic error reported by the activity runtime.
In such case, mapper fails to resolve $error.activity. 
This change will use current activity name when $error scope is constructed. 