### PR TITLE
Propagate unhandled flow error to trigger

### DIFF
--- a/action/flow/action.go
+++ b/action/flow/action.go
@@ -335,6 +335,8 @@ func (fa *FlowAction) Run(context context.Context, inputs map[string]*data.Attri
 		if inst.Status() == model.FlowStatusCompleted {
 			returnData, err := inst.GetReturnData()
 			handler.HandleResult(returnData, err)
+		} else if inst.Status() == model.FlowStatusFailed {
+			handler.HandleResult(nil, inst.GetError())
 		}
 
 		logger.Debugf("Done Executing flow instance [%s] - Status: %d", inst.ID(), inst.Status())

--- a/action/flow/instance/instance.go
+++ b/action/flow/instance/instance.go
@@ -132,6 +132,10 @@ func (inst *Instance) GetResolver() data.Resolver {
 	return definition.GetDataResolver()
 }
 
+func (inst *Instance) GetError() ( error) {
+	return inst.returnError
+}
+
 func (inst *Instance) GetReturnData() (map[string]*data.Attribute, error) {
 
 	if inst.returnData == nil {

--- a/action/flow/instance/instances.go
+++ b/action/flow/instance/instances.go
@@ -398,6 +398,8 @@ func (inst *IndependentInstance) HandleGlobalError(containerInst *Instance, err 
 
 				//inst.scheduleEval(host)
 			}
+		}  else {
+			 inst.returnError = err
 		}
 	}
 }


### PR DESCRIPTION
Currently, unhandled error in flow is not returned to the trigger handler.
So, handler assumes its successful invocation which impacts reply accuracy of given trigger. 