### PR TITLE
Added header section to activities and triggers

### DIFF
--- a/activity/actreply/README.md
+++ b/activity/actreply/README.md
@@ -1,3 +1,7 @@
+---
+title: Reply
+weight: 4601
+---
 # flogo-reply
 This activity provides your flogo action/flow the ability to reply to a trigger invocation and set output values.
 

--- a/activity/actreturn/README.md
+++ b/activity/actreturn/README.md
@@ -1,3 +1,7 @@
+---
+title: Return
+weight: 4602
+---
 # flogo-return
 This activity provides your flogo action/flow the ability to return immediately and set output values.
 

--- a/activity/aggregate/README.md
+++ b/activity/aggregate/README.md
@@ -1,3 +1,7 @@
+---
+title: Aggregate
+weight: 4603
+---
 # tibco-aggregate
 This activity provides your flogo application with rudimentary aggregation.
 

--- a/activity/app/README.md
+++ b/activity/app/README.md
@@ -1,3 +1,7 @@
+---
+title: App
+weight: 4604
+---
 # tibco-app
 This activity provides your Flogo application the ability to use a global attributes.
 

--- a/activity/awsiot/README.md
+++ b/activity/awsiot/README.md
@@ -1,5 +1,9 @@
+---
+title: AWS IoT
+weight: 4605
+---
 # tibco-awsiot
-This activity provides your flogo application the ability to update a device shadow on Aws.
+This activity provides your flogo application the ability to update a device shadow on AWS.
 
 
 ## Installation

--- a/activity/awssns/README.md
+++ b/activity/awssns/README.md
@@ -1,3 +1,7 @@
+---
+title: Amazon SNS
+weight: 4606
+---
 # Amazon SNS - SMS
 This activity sends SMS using Amazon Simple Notification Services (SNS).
 

--- a/activity/coap/README.md
+++ b/activity/coap/README.md
@@ -1,3 +1,7 @@
+---
+title: CoAP
+weight: 4607
+---
 # tibco-coap
 This activity provides your flogo application the ability to send a CoAP message.
 

--- a/activity/couchbase/README.md
+++ b/activity/couchbase/README.md
@@ -1,3 +1,7 @@
+---
+title: Coachbase
+weight: 4608
+---
 # tibco-couchbase
 This activity provides your flogo application the ability to connect to a Couchbase server
 

--- a/activity/counter/README.md
+++ b/activity/counter/README.md
@@ -1,3 +1,7 @@
+---
+title: Counter
+weight: 4609
+---
 # tibco-counter
 This activity provides your flogo application the ability to use a global counter.
 

--- a/activity/error/README.md
+++ b/activity/error/README.md
@@ -1,3 +1,7 @@
+---
+title: Error
+weight: 4610
+---
 # tibco-rest
 This activity provides your flogo application the ability to cause an explicit error in the flow.
 

--- a/activity/gpio/README.md
+++ b/activity/gpio/README.md
@@ -1,3 +1,7 @@
+---
+title: GPIO
+weight: 4611
+---
 # tibco-gpio
 This activity provides your flogo application the ability to control raspberry pi GPIO
 

--- a/activity/kafkapub/README.md
+++ b/activity/kafkapub/README.md
@@ -1,3 +1,7 @@
+---
+title: Publish Kafka Message
+weight: 4613
+---
 # tibco-kafkapub
 This activity provides your flogo application the ability to send a Kafka message
 

--- a/activity/lambda/README.md
+++ b/activity/lambda/README.md
@@ -1,3 +1,7 @@
+---
+title: Trigger Lambda Function
+weight: 4614
+---
 # tibco-lambda
 This activity provides native Lambda invocation capabilities to your Flogo apps. You can invoke a lambda function via ARN and provide the access key and secret for authentication.
 

--- a/activity/log/README.md
+++ b/activity/log/README.md
@@ -1,3 +1,7 @@
+---
+title: Log
+weight: 4615
+---
 # tibco-log
 This activity provides your flogo application with rudementary logging.
 

--- a/activity/mapper/README.md
+++ b/activity/mapper/README.md
@@ -1,3 +1,7 @@
+---
+title: Mapper
+weight: 4616
+---
 # flogo-mapper
 This activity provides your flogo application the ability to map values on to the action/flow working attribute set.
 

--- a/activity/reply/README.md
+++ b/activity/reply/README.md
@@ -1,3 +1,7 @@
+---
+title: Reply (Legacy)
+weight: 4617
+---
 # tibco-reply
 This activity provides your flogo application the ability to reply to a trigger invocation.
 

--- a/activity/rest/README.md
+++ b/activity/rest/README.md
@@ -1,3 +1,7 @@
+---
+title: REST
+weight: 4618
+---
 # tibco-rest
 This activity provides your flogo application the ability to invoke a REST service.
 

--- a/activity/subflow/README.md
+++ b/activity/subflow/README.md
@@ -1,3 +1,7 @@
+---
+title: Subflow
+weight: 4619
+---
 # flogo-subflow
 This activity provides your flogo flow the ability to start a sub-flow.
 

--- a/activity/twilio/README.md
+++ b/activity/twilio/README.md
@@ -1,3 +1,7 @@
+---
+title: Twilio
+weight: 4620
+---
 # tibco-twilio
 This activity provides your flogo application the ability to send a SMS via Twilio.
 

--- a/activity/wsmessage/readme.md
+++ b/activity/wsmessage/readme.md
@@ -1,3 +1,7 @@
+---
+title: WebSocket Message
+weight: 4621
+---
 ![gofmt status](https://img.shields.io/badge/gofmt-compliant-green.svg?style=flat-square) ![golint status](https://img.shields.io/badge/golint-compliant-green.svg?style=flat-square) ![automated test coverage](https://img.shields.io/badge/test%20coverage-1%20testcase-orange.svg?style=flat-square)
 
 # sendWSMessage

--- a/trigger/cli/README.md
+++ b/trigger/cli/README.md
@@ -1,3 +1,7 @@
+---
+title: CLI
+weight: 4701
+---
 # tibco-cli
 This trigger provides your flogo application the ability to run as a CLI app, that is, accept input via the CLI & run once till completion and return the results to stdout.
 

--- a/trigger/coap/README.md
+++ b/trigger/coap/README.md
@@ -1,3 +1,7 @@
+---
+title: CoAP
+weight: 4702
+---
 # tibco-coap
 This trigger provides your flogo application the ability to start a flow via CoAP
 

--- a/trigger/kafkasub/README.md
+++ b/trigger/kafkasub/README.md
@@ -1,3 +1,7 @@
+---
+title: Receive Kafka Message
+weight: 4703
+---
 # tibco-kafkasub
 This trigger provides your flogo application with the ability to subscribe to messages from a kafka cluster and start a flow with the contents of the message.  It is assumed that the messages plain text.  The trigger supports TLS and SASL.  
 To make a TLS connection specifiy a trust dir containing the caroots for your kafka server and a broker URL which points to an SSL port.

--- a/trigger/lambda/README.md
+++ b/trigger/lambda/README.md
@@ -1,3 +1,7 @@
+---
+title: Lambda
+weight: 4704
+---
 # tibco-lambda
 This trigger provides your flogo application the ability to start a flow as an AWS Lambda function
 

--- a/trigger/mqtt/README.md
+++ b/trigger/mqtt/README.md
@@ -1,3 +1,7 @@
+---
+title: MQTT
+weight: 4705
+---
 # tibco-mqtt
 This trigger provides your flogo application the ability to start a flow via MQTT
 

--- a/trigger/rest/README.md
+++ b/trigger/rest/README.md
@@ -1,3 +1,7 @@
+---
+title: REST
+weight: 4706
+---
 # tibco-rest
 This trigger provides your flogo application the ability to start a flow via REST over HTTP
 

--- a/trigger/timer/README.md
+++ b/trigger/timer/README.md
@@ -1,3 +1,7 @@
+---
+title: Timer
+weight: 4707
+---
 # tibco-timer
 This trigger provides your flogo application the ability to schedule a flow via scheduling service
 


### PR DESCRIPTION
I've added a header section to the README.md files of all triggers and activities. 
The header section looks like:
```
---
title: CLI
weight: 4701
---
```
This will make it possible for the automated build of the flogo repo to automatically add the readme files of the activities and triggers into the documentation and thus providing instant docs 😄 

Please note that no code has been changed, neither have the README.md files been checked for validity (that is still to be done as mentioned in https://github.com/TIBCOSoftware/flogo-contrib/issues/170)