### PR TITLE
Update CLI trigger with commandline parsing

### DIFF
--- a/trigger/cli/README.md
+++ b/trigger/cli/README.md
@@ -37,15 +37,23 @@ Settings, Outputs and Endpoint:
 }
 ```
 ## Settings
-### Trigger:
-| Output     | Description    |
-|:------------|:---------------|
-| args | The array of arguments |         
+### Trigger
+| Output      | Description                        |
+|:------------|:-----------------------------------|
+| args        | An array of command line arguments |  
+
+
+The array contains the command-line flags from `os.Args[2:]`, `os.Args[1]` is used to determine which flow is called. So a Flogo app with a CLI trigger that is started like:
+```
+$ ./cliapp -myflow -param1 foo -param2 bar 
+```
+will result in the engine executing the flow where the `handler.settings.command` field is `myflow` and pass on the other four arguments in the array `args`.
+
 ### Handler:
-| Setting     | Description    |
-|:------------|:---------------|
-| command      | The command invoked |         
-| default      | Indicates if its the default command  |
+| Setting      | Description                          |
+|:-------------|:-------------------------------------|
+| command      | The command invoked                  |         
+| default      | Indicates if its the default command |
 
 
 ## Example Configurations
@@ -57,22 +65,29 @@ Configure the Trigger to execute one flow
 
 ```json
 {
-    "triggers": [
-      {
-        "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
-        "description": "Simple CLI trigger",
-        "settings": {},
-        "id": "main",
-        "handlers": [
-          {
-            "settings": {
-              "default": true
-            },
-            "actionId": "log_cli"
+"triggers": [
+    {
+      "id": "cli_trigger",
+      "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
+      "name": "CLI Trigger",
+      "description": "Simple CLI Trigger",
+      "settings": {},
+      "handlers": [
+        {
+          "action": {
+            "ref": "github.com/TIBCOSoftware/flogo-contrib/action/flow",
+            "data": {
+              "flowURI": "res://flow:version"
+            }
+          },
+          "settings": {
+            "command": "version",
+            "default": true
           }
-        ]
-      }
-    ]
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -81,27 +96,63 @@ Configure the Trigger to handle multiple commands
 
 ```json
 {
-    "triggers": [
-      {
-        "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
-        "description": "Simple CLI trigger",
-        "settings": {},
-        "id": "main",
-        "handlers": [
-          {
-            "settings": {
-              "command": "list"
-            },
-            "actionId": "list_flow"
+"triggers": [
+    {
+      "id": "cli_trigger",
+      "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/cli",
+      "name": "CLI Trigger",
+      "description": "Simple CLI Trigger",
+      "settings": {},
+      "handlers": [
+        {
+          "action": {
+            "ref": "github.com/TIBCOSoftware/flogo-contrib/action/flow",
+            "data": {
+              "flowURI": "res://flow:version"
+            }
           },
-          {
-            "settings": {
-              "command": "run"
-            },
-            "actionId": "run_flow"
+          "settings": {
+            "command": "version",
+            "default": false
           }
-        ]
-      }
-    ]
+        },
+        {
+          "action": {
+            "ref": "github.com/TIBCOSoftware/flogo-contrib/action/flow",
+            "data": {
+              "flowURI": "res://flow:search"
+            },
+            "mappings": {
+              "input": [
+                {
+                  "mapTo": "commandline",
+                  "type": "assign",
+                  "value": "$.args"
+                }
+              ]
+            }
+          },
+          "settings": {
+            "command": "search",
+            "default": false
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Map arguments
+To use the _args_ array from the trigger you'll need to specify an input parameter of type array and map the args from the trigger to it.
+```json
+"mappings": {
+  "input": [
+    {
+      "mapTo": "commandline",
+      "type": "assign",
+      "value": "$.args"
+    }
+  ]
 }
 ```

--- a/trigger/cli/trigger.go
+++ b/trigger/cli/trigger.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/TIBCOSoftware/flogo-lib/config"
@@ -116,9 +117,15 @@ func (t *CliTrigger) Stop() error {
 }
 
 func Invoke() (string, error) {
+	// Build an array of flags that are not the command
+	// before we parse the flags, otherwise extra flags
+	// will be seen as an error
+	args := os.Args[2:]
+
+	// Create a new string array
+	os.Args = []string{"", os.Args[1]}
 
 	flag.Parse()
-	args := flag.Args()
 
 	for _, info := range singleton.handlerInfos {
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[X] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: https://github.com/TIBCOSoftware/flogo/issues/280

**What is the current behavior?** The current version of the cli trigger doesn't allow you to specify additional flags as arguments, so `cliapp -search -type trigger` results in the error
```
flag provided but not defined: -type
```

**What is the new behavior?** The new behavior sends `-type` and `trigger` as args into the executed flow
