### PR TITLE
Lambda updates

### DIFF
--- a/trigger/lambda/shim/shim.go
+++ b/trigger/lambda/shim/shim.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"reflect"
 
 	fl "github.com/TIBCOSoftware/flogo-contrib/trigger/lambda"
 	"github.com/aws/aws-lambda-go/events"
@@ -73,7 +74,15 @@ func coerceResponseObj(result map[string]interface{}, evtTyp uint) (interface{},
 					return statusCode
 				}
 			}(),
-			Body:            string(responseRaw),
+			Body: func() string {
+				v := reflect.ValueOf(responseData)
+				switch v.Kind() {
+				case reflect.String:
+					return responseData.(string)
+				default:
+					return string(responseRaw)
+				}
+			}(),
 			IsBase64Encoded: false,
 		}
 

--- a/trigger/lambda/shim/shim.go
+++ b/trigger/lambda/shim/shim.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"reflect"
 
 	fl "github.com/TIBCOSoftware/flogo-contrib/trigger/lambda"
 	"github.com/aws/aws-lambda-go/events"
@@ -75,11 +74,10 @@ func coerceResponseObj(result map[string]interface{}, evtTyp uint) (interface{},
 				}
 			}(),
 			Body: func() string {
-				v := reflect.ValueOf(responseData)
-				switch v.Kind() {
-				case reflect.String:
-					return responseData.(string)
-				default:
+				val, ok := responseData.(string)
+				if ok {
+					return val
+				} else {
 					return string(responseRaw)
 				}
 			}(),

--- a/trigger/lambda/trigger.json
+++ b/trigger/lambda/trigger.json
@@ -22,7 +22,7 @@
   "reply": [
     {
       "name": "data",
-      "type": "object"
+      "type": "any"
     },
     {
       "name": "status",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[X] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```
**What is the current behavior?** In the current Lambda trigger, the object returned to the caller is an object meaning you can only have a JSON object as a response. For some Gateway operations that might not be the best approach. Also the string that is sent back, is URL encoded which isn't great for API gateway responses where the body shouldn't be URL encoded.

**What is the new behavior?** 

* The reply is now type `any` in the trigger.json
* There is a switch statement in the API Gateway response, if the response is of type string it won't decode it to a JSON object
