### PR TITLE
cli trigger: pass in only the cmd args for flow logic to the flow

### DIFF
--- a/trigger/cli/trigger.go
+++ b/trigger/cli/trigger.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 	"reflect"
 
 	"github.com/TIBCOSoftware/flogo-lib/config"
@@ -117,15 +116,16 @@ func (t *CliTrigger) Stop() error {
 }
 
 func Invoke() (string, error) {
-	// Build an array of flags that are not the command
-	// before we parse the flags, otherwise extra flags
-	// will be seen as an error
-	args := os.Args[2:]
 
-	// Create a new string array
-	os.Args = []string{"", os.Args[1]}
-
+	var args []string
 	flag.Parse()
+
+	// if we have additional args (after the cmd name and the flow cmd switch)
+	// stuff those into args and pass to Invoke(). The action will only receive the
+	// aditional args that were intending for the action logic.
+	if arg := flag.Args(); len(arg) >= 2 {
+		args = flag.Args()[2:]
+	}
 
 	for _, info := range singleton.handlerInfos {
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**What is the current behavior?**
Currently if no args are passed into the command the following error is thrown:

```go
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
PredictMovement/vendor/github.com/TIBCOSoftware/flogo-contrib/trigger/cli.Invoke(0x11c182f0, 0x0, 0x1, 0x3f070)
/home/pi/PredictMovement/src/PredictMovement/vendor/github.com/TIBCOSoftware/flogo-contrib/trigger/cli/trigger.go:123 +0x238
main.main()
/home/pi/PredictMovement/src/PredictMovement/shim.go:11 +0x14
```

**What is the new behavior?**
Implement similar logic, that is, only pass in the commands after the cmd (the bin name) & action command switch to the flow/action. If no additional cmd line args are provided, an empty string is passed.
