### PR TITLE
Make iterator error msg more clear

### DIFF
--- a/action/flow/model/simple/iteratorbehavior.go
+++ b/action/flow/model/simple/iteratorbehavior.go
@@ -45,7 +45,7 @@ func (tb *IteratorTaskBehavior) Eval(ctx model.TaskContext) (evalResult model.Ev
 		case string:
 			count, err := data.CoerceToInteger(iterateOn)
 			if err != nil {
-				err = fmt.Errorf("unsupported string '%s' for iterator", iterateOn)
+				err = fmt.Errorf("Iterator '%s' not properly configured. '%s' is not a valid iterate value.", task.Name(), iterateOn)
 				logger.Error(err)
 				return model.EVAL_FAIL, err
 			}

--- a/action/flow/model/simple/iteratorbehavior.go
+++ b/action/flow/model/simple/iteratorbehavior.go
@@ -45,7 +45,8 @@ func (tb *IteratorTaskBehavior) Eval(ctx model.TaskContext) (evalResult model.Ev
 		case string:
 			count, err := data.CoerceToInteger(iterateOn)
 			if err != nil {
-				logger.Errorf("unsupported string %s for iterator", iterateOn)
+				err = fmt.Errorf("unsupported string %s for iterator", iterateOn)
+				logger.Error(err)
 				return model.EVAL_FAIL, err
 			}
 			itx = NewIntIterator(count)

--- a/action/flow/model/simple/iteratorbehavior.go
+++ b/action/flow/model/simple/iteratorbehavior.go
@@ -69,7 +69,9 @@ func (tb *IteratorTaskBehavior) Eval(ctx model.TaskContext) (evalResult model.Ev
 			if rt == reflect.Array || rt == reflect.Slice {
 				itx = NewReflectIterator(val)
 			} else {
-				return model.EVAL_FAIL, fmt.Errorf("unsupported type '%s' for iterateOn", t)
+				err = fmt.Errorf("Iterator '%s' not properly configured. '%s' is not a valid iterate value.", task.Name(), iterateOn)
+				logger.Error(err)
+				return model.EVAL_FAIL, err
 			}
 		}
 

--- a/action/flow/model/simple/iteratorbehavior.go
+++ b/action/flow/model/simple/iteratorbehavior.go
@@ -69,7 +69,7 @@ func (tb *IteratorTaskBehavior) Eval(ctx model.TaskContext) (evalResult model.Ev
 			if rt == reflect.Array || rt == reflect.Slice {
 				itx = NewReflectIterator(val)
 			} else {
-				err = fmt.Errorf("Iterator '%s' not properly configured. '%s' is not a valid iterate value.", task.Name(), iterateOn)
+				err = fmt.Errorf("Iterator '%s' not properly configured. '%+v' is not a valid iterate value.", task.Name(), iterateOn)
 				logger.Error(err)
 				return model.EVAL_FAIL, err
 			}

--- a/action/flow/model/simple/iteratorbehavior.go
+++ b/action/flow/model/simple/iteratorbehavior.go
@@ -45,7 +45,7 @@ func (tb *IteratorTaskBehavior) Eval(ctx model.TaskContext) (evalResult model.Ev
 		case string:
 			count, err := data.CoerceToInteger(iterateOn)
 			if err != nil {
-				err = fmt.Errorf("unsupported string %s for iterator", iterateOn)
+				err = fmt.Errorf("unsupported string '%s' for iterator", iterateOn)
 				logger.Error(err)
 				return model.EVAL_FAIL, err
 			}

--- a/action/flow/model/simple/iteratorbehavior.go
+++ b/action/flow/model/simple/iteratorbehavior.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/TIBCOSoftware/flogo-contrib/action/flow/model"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"reflect"
 )
 
@@ -44,6 +45,7 @@ func (tb *IteratorTaskBehavior) Eval(ctx model.TaskContext) (evalResult model.Ev
 		case string:
 			count, err := data.CoerceToInteger(iterateOn)
 			if err != nil {
+				logger.Errorf("unsupported string %s for iterator", iterateOn)
 				return model.EVAL_FAIL, err
 			}
 			itx = NewIntIterator(count)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[*] Other... Please describe: Make error message more clear and add an error log while iterate value invalid
```

**Fixes**: #

**What is the current behavior?**
The message is not cleary while giving a string for iterate field, (strconv.Atoi: parsing "string": invalid syntax) and there is no log while given an invalid iterate value.
**What is the new behavior?**
print an error log when user-specific an invalid iterate value and give clearly message say. unsupported string xxxxx for iterator
