### PR TITLE
Twilio activity does not return error to the flow

### DIFF
--- a/activity/twilio/activity.go
+++ b/activity/twilio/activity.go
@@ -47,6 +47,7 @@ func (a *TwilioActivity) Eval(context activity.Context) (done bool, err error) {
 
 	if err != nil {
 		log.Error("Error sending SMS:", err)
+		return false, err
 	}
 
 	log.Debug("Response:", resp)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: 
# Twilio activity does not return the error to the flow

**What is the current behavior?**
When the twilio.SendSMS function returns an error, the activity logs the error and returns done := true, err := nil

**What is the new behavior?**
When the twilio.SendSMS function returns an error, the activity logs the error and returns done := false, err := twilioErr