### PR TITLE
handle string to make sure response as json rather than escaped string

### DIFF
--- a/trigger/rest/trigger.go
+++ b/trigger/rest/trigger.go
@@ -219,10 +219,19 @@ func newActionHandler(rt *RestTrigger, handler *trigger.Handler) httprouter.Hand
 				replyCode = 200
 			}
 			w.WriteHeader(replyCode)
-			if err := json.NewEncoder(w).Encode(replyData); err != nil {
-				log.Error(err)
+			switch t := replyData.(type) {
+			case string:
+				_, err := w.Write([]byte(t))
+				if err != nil {
+					log.Error(err)
+				}
+				return
+			default:
+				if err := json.NewEncoder(w).Encode(replyData); err != nil {
+					log.Error(err)
+				}
+				return
 			}
-			return
 		}
 
 		if replyCode > 0 {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Rest trigger response an escaped JSON to the client when we provide or map a literal JSON string to rest reply data field.
**What is the new behavior?**
We should make sure the literal string returns as JSON rather than an escaped string.