### PR TITLE
Fix issue #317

### DIFF
--- a/action/flow/instance/instances.go
+++ b/action/flow/instance/instances.go
@@ -299,7 +299,7 @@ func (inst *IndependentInstance) handleTaskDone(taskBehavior model.TaskBehavior,
 			if ok {
 				//if the flow failed, set the error
 				for _, value := range containerInst.returnData {
-					host.SetOutput(value.Name(), value)
+					host.SetOutput(value.Name(), value.Value())
 				}
 
 				inst.scheduleEval(host)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #317 

**What is the current behavior?**
Map subflow activity's output to a log message and it get `2019-01-03 15:27:42.856 INFO [activity-flogo-log] - {"name":"output2","type":"string","value":"subflow output"}` but  it should be only value, eg `subflow output`
**What is the new behavior?**
Just get subflow output's value rather than whole attribute struct.